### PR TITLE
Refactor store state management for performance

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -21,6 +21,17 @@ export {
   useSelectedActor,
   useActorsByType,
   useActorList,
+  useEnvironment,
+  useAmbientLight,
+  useSun,
+  useSkyColor,
+  useTimeline,
+  useAnimationTracks,
+  useCameraTrack,
+  useTimelineMetadata,
+  usePlaybackState,
+  useMeta,
+  useLibrary,
 } from './store/sceneStore';
 
 // === COMPONENTS (R3F) ===

--- a/packages/engine/src/scene/SceneManager.test.tsx
+++ b/packages/engine/src/scene/SceneManager.test.tsx
@@ -2,11 +2,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 import { SceneManager } from './SceneManager'
-import { useSceneStore } from '../store/sceneStore'
+import * as store from '../store/sceneStore'
 
 // Mock the store
 vi.mock('../store/sceneStore', () => ({
   useSceneStore: vi.fn(),
+  useActorList: vi.fn(),
+  useAmbientLight: vi.fn(),
+  useAnimationTracks: vi.fn(),
+  useCameraTrack: vi.fn(),
+  useCurrentTime: vi.fn(),
+  useEnvironment: vi.fn(),
+  useSkyColor: vi.fn(),
+  useSun: vi.fn(),
 }))
 
 // Mock renderers to render visible elements we can query
@@ -45,37 +53,19 @@ describe('SceneManager', () => {
     vi.clearAllMocks()
 
     // Setup default store mock behavior
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-      const state = {
-        actors: [],
-        environment: {
-          ambientLight: { intensity: 0.5, color: '#ffffff' },
-          sun: { position: [10, 10, 10], intensity: 1, color: '#ffffff' },
-          skyColor: '#87CEEB',
-        },
-        timeline: {
-          cameraTrack: [],
-          animationTracks: [],
-        },
-        playback: {
-          currentTime: 0,
-        },
-      }
-      return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue([])
+    ;(store.useAmbientLight as any).mockReturnValue({ intensity: 0.5, color: '#ffffff' })
+    ;(store.useSun as any).mockReturnValue({ position: [10, 10, 10], intensity: 1, color: '#ffffff' })
+    ;(store.useSkyColor as any).mockReturnValue('#87CEEB')
+    ;(store.useEnvironment as any).mockReturnValue({})
+    ;(store.useAnimationTracks as any).mockReturnValue([])
+    ;(store.useCameraTrack as any).mockReturnValue([])
+    ;(store.useCurrentTime as any).mockReturnValue(0)
   })
 
   it('renders primitive actors', () => {
     const actors = [{ id: '1', type: 'primitive' }]
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-       const state = {
-         actors,
-         environment: { ambientLight: {}, sun: {}, skyColor: '#000' },
-         timeline: { cameraTrack: [], animationTracks: [] },
-         playback: { currentTime: 0 },
-       }
-       return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue(actors)
 
     const { getByTestId } = render(<SceneManager />)
     expect(getByTestId('primitive-renderer')).toBeDefined()
@@ -83,15 +73,7 @@ describe('SceneManager', () => {
 
   it('renders light actors', () => {
     const actors = [{ id: '2', type: 'light' }]
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-       const state = {
-         actors,
-         environment: { ambientLight: {}, sun: {}, skyColor: '#000' },
-         timeline: { cameraTrack: [], animationTracks: [] },
-         playback: { currentTime: 0 },
-       }
-       return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue(actors)
 
     const { getByTestId } = render(<SceneManager />)
     expect(getByTestId('light-renderer')).toBeDefined()
@@ -99,15 +81,7 @@ describe('SceneManager', () => {
 
   it('renders camera actors', () => {
     const actors = [{ id: '3', type: 'camera' }]
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-       const state = {
-         actors,
-         environment: { ambientLight: {}, sun: {}, skyColor: '#000' },
-         timeline: { cameraTrack: [], animationTracks: [] },
-         playback: { currentTime: 0 },
-       }
-       return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue(actors)
 
     const { getByTestId } = render(<SceneManager />)
     expect(getByTestId('camera-renderer')).toBeDefined()
@@ -115,15 +89,7 @@ describe('SceneManager', () => {
 
   it('renders character actors', () => {
     const actors = [{ id: '4', type: 'character' }]
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-       const state = {
-         actors,
-         environment: { ambientLight: {}, sun: {}, skyColor: '#000' },
-         timeline: { cameraTrack: [], animationTracks: [] },
-         playback: { currentTime: 0 },
-       }
-       return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue(actors)
 
     const { getByTestId } = render(<SceneManager />)
     expect(getByTestId('character-renderer')).toBeDefined()
@@ -131,15 +97,7 @@ describe('SceneManager', () => {
 
   it('renders speaker actors', () => {
     const actors = [{ id: '5', type: 'speaker' }]
-    ;(useSceneStore as any).mockImplementation((selector: any) => {
-       const state = {
-         actors,
-         environment: { ambientLight: {}, sun: {}, skyColor: '#000' },
-         timeline: { cameraTrack: [], animationTracks: [] },
-         playback: { currentTime: 0 },
-       }
-       return selector(state)
-    })
+    ;(store.useActorList as any).mockReturnValue(actors)
 
     const { getByTestId } = render(<SceneManager />)
     expect(getByTestId('speaker-renderer')).toBeDefined()

--- a/packages/engine/src/scene/SceneManager.tsx
+++ b/packages/engine/src/scene/SceneManager.tsx
@@ -6,7 +6,16 @@
  * @module @animatica/engine/scene/SceneManager
  */
 import React, { useMemo } from 'react';
-import { useSceneStore } from '../store/sceneStore';
+import {
+    useActorList,
+    useAmbientLight,
+    useAnimationTracks,
+    useCameraTrack,
+    useCurrentTime,
+    useEnvironment,
+    useSkyColor,
+    useSun,
+} from '../store/sceneStore';
 import { evaluateTracksAtTime } from '../animation/interpolate';
 import { applyAnimationToActor, resolveActiveCamera } from './animationUtils';
 import { PrimitiveRenderer } from './renderers/PrimitiveRenderer';
@@ -23,92 +32,83 @@ import type {
     SpeakerActor,
 } from '../types';
 
-interface SceneManagerProps {
-    /** ID of the currently selected actor in the editor. */
+/**
+ * SceneEnvironment — Renders lights, sky, and fog.
+ * Subscribes only to environment state to avoid re-renders during playback.
+ */
+const SceneEnvironment: React.FC = React.memo(() => {
+    const ambientLight = useAmbientLight();
+    const sun = useSun();
+    const skyColor = useSkyColor();
+    const { fog } = useEnvironment();
+
+    return (
+        <>
+            <ambientLight intensity={ambientLight.intensity} color={ambientLight.color} />
+            <directionalLight
+                position={sun.position as unknown as [number, number, number]}
+                intensity={sun.intensity}
+                color={sun.color}
+                castShadow
+            />
+            <color attach="background" args={[skyColor]} />
+
+            {fog && <fog attach="fog" args={[fog.color, fog.near, fog.far]} />}
+        </>
+    );
+});
+
+SceneEnvironment.displayName = 'SceneEnvironment';
+
+interface SceneActorsProps {
     selectedActorId?: string;
-    /** Callback when an actor is clicked. */
     onActorSelect?: (actorId: string) => void;
-    /** Whether to show debug helpers (light gizmos, camera frustums). */
     showHelpers?: boolean;
 }
 
 /**
- * SceneManager — the main scene orchestrator.
- * Reads actors, timeline, and environment from the Zustand store
- * and renders everything using the appropriate renderer components.
- *
- * @component
- * @example
- * ```tsx
- * <Canvas>
- *   <SceneManager
- *     selectedActorId={selectedId}
- *     onActorSelect={(id) => setSelectedId(id)}
- *     showHelpers={true}
- *   />
- * </Canvas>
- * ```
+ * SceneActors — Renders all actors and handles animation interpolation.
+ * Subscribes to currentTime to drive animations.
  */
-export const SceneManager: React.FC<SceneManagerProps> = ({
+const SceneActors: React.FC<SceneActorsProps> = ({
     selectedActorId,
     onActorSelect,
     showHelpers = false,
 }) => {
-    const actors = useSceneStore((s) => s.actors);
-    const environment = useSceneStore((s) => s.environment);
-    const timeline = useSceneStore((s) => s.timeline);
-    const currentTime = useSceneStore((s) => s.playback.currentTime);
+    const actors = useActorList();
+    const animationTracks = useAnimationTracks();
+    const cameraTrack = useCameraTrack();
+    const currentTime = useCurrentTime();
 
     // Evaluate all animation tracks at the current time
     const animationValues = useMemo(
-        () => evaluateTracksAtTime(timeline.animationTracks, currentTime),
-        [timeline.animationTracks, currentTime],
+        () => evaluateTracksAtTime(animationTracks, currentTime),
+        [animationTracks, currentTime]
     );
 
     // Sort camera cuts only when the track changes, not every frame
     const sortedCameraCuts = useMemo(
-        () => [...timeline.cameraTrack].sort((a, b) => a.time - b.time),
-        [timeline.cameraTrack]
+        () => [...cameraTrack].sort((a, b) => a.time - b.time),
+        [cameraTrack]
     );
 
     // Determine the active camera from the sorted camera cuts
     const activeCameraId = useMemo(
         () => resolveActiveCamera(sortedCameraCuts, currentTime),
-        [sortedCameraCuts, currentTime],
+        [sortedCameraCuts, currentTime]
     );
 
     // Apply animation values to actors
     const animatedActors = useMemo(
         () =>
             actors.map((actor: Actor) =>
-                applyAnimationToActor(actor, animationValues.get(actor.id)),
+                applyAnimationToActor(actor, animationValues.get(actor.id))
             ),
-        [actors, animationValues],
+        [actors, animationValues]
     );
 
     return (
         <>
-            {/* === Environment === */}
-            <ambientLight
-                intensity={environment.ambientLight.intensity}
-                color={environment.ambientLight.color}
-            />
-            <directionalLight
-                position={environment.sun.position as unknown as [number, number, number]}
-                intensity={environment.sun.intensity}
-                color={environment.sun.color}
-                castShadow
-            />
-            <color attach="background" args={[environment.skyColor]} />
-
-            {environment.fog && (
-                <fog
-                    attach="fog"
-                    args={[environment.fog.color, environment.fog.near, environment.fog.far]}
-                />
-            )}
-
-            {/* === Actors === */}
             {animatedActors.map((actor: Actor) => {
                 switch (actor.type) {
                     case 'primitive':
@@ -163,6 +163,51 @@ export const SceneManager: React.FC<SceneManagerProps> = ({
                         return null;
                 }
             })}
+        </>
+    );
+};
+
+SceneActors.displayName = 'SceneActors';
+
+interface SceneManagerProps {
+    /** ID of the currently selected actor in the editor. */
+    selectedActorId?: string;
+    /** Callback when an actor is clicked. */
+    onActorSelect?: (actorId: string) => void;
+    /** Whether to show debug helpers (light gizmos, camera frustums). */
+    showHelpers?: boolean;
+}
+
+/**
+ * SceneManager — the main scene orchestrator.
+ * Reads actors, timeline, and environment from the Zustand store
+ * and renders everything using the appropriate renderer components.
+ *
+ * @component
+ * @example
+ * ```tsx
+ * <Canvas>
+ *   <SceneManager
+ *     selectedActorId={selectedId}
+ *     onActorSelect={(id) => setSelectedId(id)}
+ *     showHelpers={true}
+ *   />
+ * </Canvas>
+ * ```
+ */
+export const SceneManager: React.FC<SceneManagerProps> = ({
+    selectedActorId,
+    onActorSelect,
+    showHelpers = false,
+}) => {
+    return (
+        <>
+            <SceneEnvironment />
+            <SceneActors
+                selectedActorId={selectedActorId}
+                onActorSelect={onActorSelect}
+                showHelpers={showHelpers}
+            />
         </>
     );
 };

--- a/packages/engine/src/store/sceneStore.ts
+++ b/packages/engine/src/store/sceneStore.ts
@@ -138,3 +138,64 @@ export const useActorsByType = (type: Actor['type']) =>
  * Hook to get the list of all actors.
  */
 export const useActorList = () => useSceneStore((state) => state.actors);
+
+/**
+ * Hook to get the entire environment state.
+ */
+export const useEnvironment = () => useSceneStore(useShallow((state) => state.environment));
+
+/**
+ * Hook to get ambient light settings.
+ */
+export const useAmbientLight = () => useSceneStore(useShallow((state) => state.environment.ambientLight));
+
+/**
+ * Hook to get sun (directional light) settings.
+ */
+export const useSun = () => useSceneStore(useShallow((state) => state.environment.sun));
+
+/**
+ * Hook to get the background sky color.
+ */
+export const useSkyColor = () => useSceneStore((state) => state.environment.skyColor);
+
+/**
+ * Hook to get the entire timeline state.
+ */
+export const useTimeline = () => useSceneStore(useShallow((state) => state.timeline));
+
+/**
+ * Hook to get all animation tracks.
+ */
+export const useAnimationTracks = () => useSceneStore(useShallow((state) => state.timeline.animationTracks));
+
+/**
+ * Hook to get the camera track (cuts).
+ */
+export const useCameraTrack = () => useSceneStore(useShallow((state) => state.timeline.cameraTrack));
+
+/**
+ * Hook to get timeline metadata (duration, markers).
+ */
+export const useTimelineMetadata = () =>
+  useSceneStore(
+    useShallow((state) => ({
+      duration: state.timeline.duration,
+      markers: state.timeline.markers,
+    }))
+  );
+
+/**
+ * Hook to get the entire playback state.
+ */
+export const usePlaybackState = () => useSceneStore(useShallow((state) => state.playback));
+
+/**
+ * Hook to get the project metadata.
+ */
+export const useMeta = () => useSceneStore(useShallow((state) => state.meta));
+
+/**
+ * Hook to get the library state.
+ */
+export const useLibrary = () => useSceneStore(useShallow((state) => state.library));

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "455.61ms",
+  "Vector3 Interpolation (10k ops)": "528.74ms",
+  "Color Interpolation (10k ops)": "488.73ms",
+  "Schema Validation Speed (100 runs)": "79.20ms",
+  "Store Playback Updates (10k ops)": "250.61ms",
+  "Store Add Actor (1k ops)": "156.42ms",
+  "Store Update Actor (1k ops)": "1313.84ms",
+  "Store Remove Actor (1k ops)": "1030.95ms"
 }


### PR DESCRIPTION
Refactored the @Animatica/engine state management to reduce unnecessary component re-renders.

Key changes:
- Added granular hooks (useEnvironment, useSun, useTimeline, etc.) in `sceneStore.ts` using `useShallow` to prevent re-renders when unrelated state changes.
- Split `SceneManager.tsx` into `SceneEnvironment` and `SceneActors`. This isolates the high-frequency `currentTime` updates (60fps during playback) to only the components that need it, preventing the entire scene environment (lights, sky) from re-rendering every frame.
- Updated `index.ts` to export the new hooks for use in other packages like `@Animatica/editor`.
- Updated `SceneManager.test.tsx` to correctly mock the new granular hook architecture.

Performance verification:
- Typechecking passes via `tsc --noEmit`.
- Unit tests for store and scene rendering pass.
- Logic remains consistent with existing engine standards.

---
*PR created automatically by Jules for task [4259392254652500116](https://jules.google.com/task/4259392254652500116) started by @Fredess74*