### PR TITLE
chore(bundle): size audit 2026-03-22

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,36 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-03-22
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 110K | +8K | First Load JS (main route) |
+| **@Animatica/engine** | 136K | +65K | Includes index.js (79K) and index.cjs (57K) |
+| **@Animatica/editor** | 3.4M | +3.3M | Includes index.js (2.1M) and index.cjs (1.3M) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**~3.5M** (excluding web), **~3.6M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4M)
+- `dist/index.js`: 2,181K
+- `dist/index.cjs`: 1,308K
+- Massive growth due to implementation of full editor UI and 600+ modules.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (136K)
+- `dist/index.js`: 79K
+- `dist/index.cjs`: 57K
+- Growth as more R3F components and animation logic are added.
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-03-22.
+- `@Animatica/editor` has grown significantly (2.1M for ES build) as it now contains the majority of the UI components.
+- `@Animatica/engine` size nearly doubled as core functionality matures.
+- `apps/web` First Load JS remains stable around 110K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Review UI dependency tree. 2.1M is quite large for a library. Consider code-splitting if not already done, or checking for heavy assets bundled as code.
+- **@Animatica/engine**: Continue monitoring, but current size is acceptable for the functionality provided.
+- **@Animatica/web**: Good performance, ensure that heavy editor components are lazy-loaded if they aren't needed on the landing page.


### PR DESCRIPTION
This PR updates the bundle size audit report in `docs/BUNDLE_REPORT.md`.

Highlights:
- **@Animatica/editor** has grown significantly to **3.4M** (from 76K) as the full UI implementation and 600+ modules are now included in the build.
- **@Animatica/engine** has reached **136K**, nearly doubling since the last audit as core features mature.
- **@Animatica/web** remains stable with a First Load JS of **110K**.

The audit was performed by running `pnpm build` and inspecting the `dist` and `.next` output directories. Pre-existing test regressions were noted but not affected by this documentation-only change.

---
*PR created automatically by Jules for task [17875912993907054283](https://jules.google.com/task/17875912993907054283) started by @Fredess74*