### PR TITLE
chore(legal): license audit

### DIFF
--- a/docs/LICENSE_AUDIT.md
+++ b/docs/LICENSE_AUDIT.md
@@ -1,874 +1,847 @@
-# License Audit
+# License Audit Report
 
-**Date:** 2026-02-25
-**Auditor:** Jules (License Auditor)
+Date: 2026-03-24
 
 ## Summary
 
-This document lists all dependencies used in the project and their licenses. It also flags any non-MIT licenses and checks for the presence of the project's own LICENSE file.
+| License | Count |
+| --- | --- |
+| MIT | 578 |
+| ISC | 40 |
+| BSD-3-Clause | 25 |
+| Apache-2.0 | 17 |
+| MPL-2.0 | 7 |
+| BSD-2-Clause | 6 |
+| BSD | 3 |
+| MIT-0 | 2 |
+| LGPL-3.0-or-later | 2 |
+| BlueOak-1.0.0 | 2 |
+| BSD-3-Clause OR MIT | 1 |
+| Python-2.0 | 1 |
+| CC-BY-4.0 | 1 |
+| WTFPL | 1 |
+| PSF | 1 |
+| CC0-1.0 | 1 |
+| (MIT AND BSD-3-Clause) | 1 |
+| WTFPL OR MIT | 1 |
+| 0BSD | 1 |
+| (MIT OR CC0-1.0) | 1 |
+| LGPL-3.0 | 1 |
 
-Total dependencies found: 687
-Direct dependencies: 33
-Transitive dependencies: 654
+## 🚩 Non-MIT Licenses
 
-## Project License
+| Dependency | License | Type | Used In |
+| --- | --- | --- | --- |
+| @csstools/color-helpers | MIT-0 | Transitive |  |
+| @csstools/css-syntax-patches-for-csstree | MIT-0 | Transitive |  |
+| @dimforge/rapier3d-compat | Apache-2.0 | Transitive |  |
+| @ethereumjs/rlp | MPL-2.0 | Transitive |  |
+| @ethereumjs/util | MPL-2.0 | Transitive |  |
+| @img/sharp-libvips-linux-x64 | LGPL-3.0-or-later | Transitive |  |
+| @img/sharp-libvips-linuxmusl-x64 | LGPL-3.0-or-later | Transitive |  |
+| @img/sharp-linux-x64 | Apache-2.0 | Transitive |  |
+| @img/sharp-linuxmusl-x64 | Apache-2.0 | Transitive |  |
+| @mediapipe/tasks-vision | Apache-2.0 | Transitive |  |
+| @sentry/core | BSD-3-Clause | Transitive |  |
+| @sentry/hub | BSD-3-Clause | Transitive |  |
+| @sentry/minimal | BSD-3-Clause | Transitive |  |
+| @sentry/node | BSD-3-Clause | Transitive |  |
+| @sentry/types | BSD-3-Clause | Transitive |  |
+| @sentry/utils | BSD-3-Clause | Transitive |  |
+| @swc/helpers | Apache-2.0 | Transitive |  |
+| @webgpu/types | BSD-3-Clause | Transitive |  |
+| abbrev | ISC | Transitive |  |
+| amdefine | BSD-3-Clause OR MIT | Transitive |  |
+| ansi-align | ISC | Transitive |  |
+| antlr4ts | BSD-3-Clause | Transitive |  |
+| anymatch | ISC | Transitive |  |
+| argparse | Python-2.0 | Transitive |  |
+| aria-query | Apache-2.0 | Transitive |  |
+| at-least-node | ISC | Transitive |  |
+| baseline-browser-mapping | Apache-2.0 | Transitive |  |
+| browser-stdout | ISC | Transitive |  |
+| caniuse-lite | CC-BY-4.0 | Transitive |  |
+| caseless | Apache-2.0 | Transitive |  |
+| chai-as-promised | WTFPL | Transitive |  |
+| charenc | BSD-3-Clause | Transitive |  |
+| cliui | ISC | Transitive |  |
+| crypt | BSD-3-Clause | Transitive |  |
+| detect-libc | Apache-2.0 | Transitive |  |
+| diff | BSD-3-Clause | Transitive |  |
+| difflib | PSF | Transitive |  |
+| draco3d | Apache-2.0 | Transitive |  |
+| electron-to-chromium | ISC | Transitive |  |
+| entities | BSD-2-Clause | Transitive |  |
+| escodegen | BSD-2-Clause | Transitive |  |
+| esprima | BSD-2-Clause | Transitive |  |
+| estraverse | BSD | Transitive |  |
+| esutils | BSD-2-Clause | Transitive |  |
+| ethereumjs-util | MPL-2.0 | Transitive |  |
+| expect-type | Apache-2.0 | Transitive |  |
+| fast-uri | BSD-3-Clause | Transitive |  |
+| fastq | ISC | Transitive |  |
+| flat | BSD-3-Clause | Transitive |  |
+| fs.realpath | ISC | Transitive |  |
+| get-caller-file | ISC | Transitive |  |
+| ghost-testrpc | ISC | Transitive |  |
+| glob | ISC | Transitive |  |
+| glob-parent | ISC | Transitive |  |
+| graceful-fs | ISC | Transitive |  |
+| hls.js | Apache-2.0 | Transitive |  |
+| ieee754 | BSD-3-Clause | Transitive |  |
+| inflight | ISC | Transitive |  |
+| inherits | ISC | Transitive |  |
+| ini | ISC | Transitive |  |
+| isexe | ISC | Transitive |  |
+| json-stringify-safe | ISC | Transitive |  |
+| lightningcss | MPL-2.0 | Transitive |  |
+| lightningcss-linux-x64-gnu | MPL-2.0 | Transitive |  |
+| lightningcss-linux-x64-musl | MPL-2.0 | Transitive |  |
+| lru-cache | ISC | Transitive |  |
+| lru-cache | BlueOak-1.0.0 | Transitive |  |
+| lucide-react | ISC | Direct | @Animatica/editor, @Animatica/web |
+| make-error | ISC | Transitive |  |
+| mdn-data | CC0-1.0 | Transitive |  |
+| minimalistic-assert | ISC | Transitive |  |
+| minimatch | ISC | Transitive |  |
+| minimatch | BlueOak-1.0.0 | Transitive |  |
+| ndjson | BSD-3-Clause | Transitive |  |
+| nopt | ISC | Transitive |  |
+| once | ISC | Transitive |  |
+| parse-cache-control | BSD | Transitive |  |
+| picocolors | ISC | Transitive |  |
+| potpack | ISC | Transitive |  |
+| promise-worker-transferable | Apache-2.0 | Transitive |  |
+| qs | BSD-3-Clause | Transitive |  |
+| rlp | MPL-2.0 | Transitive |  |
+| saxes | ISC | Transitive |  |
+| sc-istanbul | BSD-3-Clause | Transitive |  |
+| semver | ISC | Transitive |  |
+| serialize-javascript | BSD-3-Clause | Transitive |  |
+| setprototypeof | ISC | Transitive |  |
+| sha.js | (MIT AND BSD-3-Clause) | Transitive |  |
+| sha1 | BSD-3-Clause | Transitive |  |
+| sharp | Apache-2.0 | Transitive |  |
+| shelljs | BSD-3-Clause | Transitive |  |
+| siginfo | ISC | Transitive |  |
+| solidity-coverage | ISC | Transitive |  |
+| source-map | BSD-3-Clause | Transitive |  |
+| source-map | BSD | Transitive |  |
+| source-map-js | BSD-3-Clause | Transitive |  |
+| split2 | ISC | Transitive |  |
+| sprintf-js | BSD-3-Clause | Transitive |  |
+| string-format | WTFPL OR MIT | Transitive |  |
+| table | BSD-3-Clause | Transitive |  |
+| tough-cookie | BSD-3-Clause | Transitive |  |
+| ts-command-line-args | ISC | Transitive |  |
+| tslib | 0BSD | Transitive |  |
+| type-fest | (MIT OR CC0-1.0) | Transitive |  |
+| typescript | Apache-2.0 | Direct | @Animatica/contracts, @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web, Animatica |
+| uglify-js | BSD-2-Clause | Transitive |  |
+| web3-utils | LGPL-3.0 | Transitive |  |
+| webidl-conversions | BSD-2-Clause | Transitive |  |
+| which | ISC | Transitive |  |
+| workerpool | Apache-2.0 | Transitive |  |
+| wrappy | ISC | Transitive |  |
+| xml-name-validator | Apache-2.0 | Transitive |  |
+| y18n | ISC | Transitive |  |
+| yallist | ISC | Transitive |  |
+| yargs-parser | ISC | Transitive |  |
 
-- **File:** `LICENSE`
-- **Status:** Present
-- **License:** MIT
+## All Dependencies
 
-## Source Code Headers
-
-- **Checked:** `packages/engine/src/index.ts`
-- **Result:** No license header found.
-
-## Flagged Licenses (Non-MIT)
-
-The following dependencies have non-MIT licenses:
-
-| Dependency | Version | License | Type |
-| --- | --- | --- |
-| @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 | Transitive |
-| @ethereumjs/rlp | 4.0.1 | MPL-2.0 | Transitive |
-| @ethereumjs/util | 8.1.0 | MPL-2.0 | Transitive |
-| @img/sharp-libvips-linux-x64 | 1.2.4 | LGPL-3.0-or-later | Transitive |
-| @img/sharp-libvips-linuxmusl-x64 | 1.2.4 | LGPL-3.0-or-later | Transitive |
-| @img/sharp-linux-x64 | 0.34.5 | Apache-2.0 | Transitive |
-| @img/sharp-linuxmusl-x64 | 0.34.5 | Apache-2.0 | Transitive |
-| @mediapipe/tasks-vision | 0.10.17 | Apache-2.0 | Transitive |
-| @sentry/core | 5.30.0 | BSD-3-Clause | Transitive |
-| @sentry/hub | 5.30.0 | BSD-3-Clause | Transitive |
-| @sentry/minimal | 5.30.0 | BSD-3-Clause | Transitive |
-| @sentry/node | 5.30.0 | BSD-3-Clause | Transitive |
-| @sentry/types | 5.30.0 | BSD-3-Clause | Transitive |
-| @sentry/utils | 5.30.0 | BSD-3-Clause | Transitive |
-| @swc/helpers | 0.5.15 | Apache-2.0 | Transitive |
-| @webgpu/types | 0.1.69 | BSD-3-Clause | Transitive |
-| abbrev | 1.0.9 | ISC | Transitive |
-| ansi-align | 3.0.1 | ISC | Transitive |
-| antlr4ts | 0.5.0-alpha.4 | BSD-3-Clause | Transitive |
-| anymatch | 3.1.3 | ISC | Transitive |
-| argparse | 2.0.1 | Python-2.0 | Transitive |
-| aria-query | 5.3.0 | Apache-2.0 | Transitive |
-| at-least-node | 1.0.0 | ISC | Transitive |
-| baseline-browser-mapping | 2.10.0 | Apache-2.0 | Transitive |
-| browser-stdout | 1.3.1 | ISC | Transitive |
-| caniuse-lite | 1.0.30001770 | CC-BY-4.0 | Transitive |
-| caseless | 0.12.0 | Apache-2.0 | Transitive |
-| chai-as-promised | 7.1.2 | WTFPL | Transitive |
-| charenc | 0.0.2 | BSD-3-Clause | Transitive |
-| cliui | 7.0.4 | ISC | Transitive |
-| crypt | 0.0.2 | BSD-3-Clause | Transitive |
-| detect-libc | 2.1.2 | Apache-2.0 | Transitive |
-| diff | 4.0.4 | BSD-3-Clause | Transitive |
-| difflib | 0.2.4 | PSF | Transitive |
-| draco3d | 1.5.7 | Apache-2.0 | Transitive |
-| electron-to-chromium | 1.5.302 | ISC | Transitive |
-| entities | 6.0.1 | BSD-2-Clause | Transitive |
-| escodegen | 1.8.1 | BSD-2-Clause | Transitive |
-| esprima | 2.7.3 | BSD-2-Clause | Transitive |
-| estraverse | 1.9.3 | BSD | Transitive |
-| esutils | 2.0.3 | BSD-2-Clause | Transitive |
-| ethereumjs-util | 7.1.5 | MPL-2.0 | Transitive |
-| expect-type | 1.3.0 | Apache-2.0 | Transitive |
-| fast-uri | 3.1.0 | BSD-3-Clause | Transitive |
-| fastq | 1.20.1 | ISC | Transitive |
-| flat | 5.0.2 | BSD-3-Clause | Transitive |
-| fs.realpath | 1.0.0 | ISC | Transitive |
-| get-caller-file | 2.0.5 | ISC | Transitive |
-| ghost-testrpc | 0.0.2 | ISC | Transitive |
-| glob | 5.0.15 | ISC | Transitive |
-| glob-parent | 5.1.2 | ISC | Transitive |
-| graceful-fs | 4.2.11 | ISC | Transitive |
-| hls.js | 1.6.15 | Apache-2.0 | Transitive |
-| ieee754 | 1.2.1 | BSD-3-Clause | Transitive |
-| inflight | 1.0.6 | ISC | Transitive |
-| inherits | 2.0.4 | ISC | Transitive |
-| ini | 1.3.8 | ISC | Transitive |
-| isexe | 2.0.0 | ISC | Transitive |
-| json-stringify-safe | 5.0.1 | ISC | Transitive |
-| lightningcss | 1.31.1 | MPL-2.0 | Transitive |
-| lightningcss-linux-x64-gnu | 1.31.1 | MPL-2.0 | Transitive |
-| lightningcss-linux-x64-musl | 1.31.1 | MPL-2.0 | Transitive |
-| lru-cache | 5.1.1 | ISC | Transitive |
-| lru-cache | 11.2.6 | BlueOak-1.0.0 | Transitive |
-| lucide-react | 0.563.0 | ISC | **Direct** |
-| make-error | 1.3.6 | ISC | Transitive |
-| mdn-data | 2.12.2 | CC0-1.0 | Transitive |
-| minimalistic-assert | 1.0.1 | ISC | Transitive |
-| minimatch | 3.1.3 | ISC | Transitive |
-| minimatch | 10.2.2 | BlueOak-1.0.0 | Transitive |
-| ndjson | 2.0.0 | BSD-3-Clause | Transitive |
-| nopt | 3.0.6 | ISC | Transitive |
-| once | 1.4.0 | ISC | Transitive |
-| parse-cache-control | 1.0.1 | BSD | Transitive |
-| picocolors | 1.1.1 | ISC | Transitive |
-| potpack | 1.0.2 | ISC | Transitive |
-| promise-worker-transferable | 1.0.4 | Apache-2.0 | Transitive |
-| qs | 6.15.0 | BSD-3-Clause | Transitive |
-| rlp | 2.2.7 | MPL-2.0 | Transitive |
-| saxes | 6.0.0 | ISC | Transitive |
-| sc-istanbul | 0.4.6 | BSD-3-Clause | Transitive |
-| semver | 5.7.2 | ISC | Transitive |
-| serialize-javascript | 6.0.2 | BSD-3-Clause | Transitive |
-| setprototypeof | 1.2.0 | ISC | Transitive |
-| sha1 | 1.1.1 | BSD-3-Clause | Transitive |
-| sharp | 0.34.5 | Apache-2.0 | Transitive |
-| shelljs | 0.8.5 | BSD-3-Clause | Transitive |
-| siginfo | 2.0.0 | ISC | Transitive |
-| solidity-coverage | 0.8.17 | ISC | Transitive |
-| source-map | 0.6.1 | BSD-3-Clause | Transitive |
-| source-map | 0.2.0 | BSD | Transitive |
-| source-map-js | 1.2.1 | BSD-3-Clause | Transitive |
-| split2 | 3.2.2 | ISC | Transitive |
-| sprintf-js | 1.0.3 | BSD-3-Clause | Transitive |
-| table | 6.9.0 | BSD-3-Clause | Transitive |
-| tough-cookie | 6.0.0 | BSD-3-Clause | Transitive |
-| ts-command-line-args | 2.5.1 | ISC | Transitive |
-| tslib | 1.14.1 | 0BSD | Transitive |
-| typescript | 5.9.3 | Apache-2.0 | **Direct** |
-| uglify-js | 3.19.3 | BSD-2-Clause | Transitive |
-| web3-utils | 1.10.4 | LGPL-3.0 | Transitive |
-| webidl-conversions | 8.0.1 | BSD-2-Clause | Transitive |
-| which | 1.3.1 | ISC | Transitive |
-| workerpool | 6.5.1 | Apache-2.0 | Transitive |
-| wrappy | 1.0.2 | ISC | Transitive |
-| xml-name-validator | 5.0.0 | Apache-2.0 | Transitive |
-| y18n | 5.0.8 | ISC | Transitive |
-| yallist | 3.1.1 | ISC | Transitive |
-| yargs-parser | 20.2.9 | ISC | Transitive |
-
-## Direct Dependencies
-
-| Dependency | License | Used In |
-| --- | --- | --- |
-| @nomicfoundation/hardhat-toolbox | MIT | @Animatica/contracts |
-| @openzeppelin/contracts | MIT | @Animatica/contracts |
-| @react-three/drei | MIT | @Animatica/engine |
-| @react-three/fiber | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
-| @tailwindcss/postcss | MIT | @Animatica/editor |
-| @testing-library/dom | MIT | @Animatica/web |
-| @testing-library/react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
-| @types/node | MIT | @Animatica/engine |
-| @types/react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| @types/react-dom | MIT | @Animatica/editor, @Animatica/platform, @Animatica/web |
-| @types/three | MIT | @Animatica/engine |
-| @types/uuid | MIT | @Animatica/engine |
-| @vitejs/plugin-react | MIT | @Animatica/editor |
-| clsx | MIT | @Animatica/editor |
-| hardhat | MIT | @Animatica/contracts |
-| immer | MIT | @Animatica/engine |
-| jsdom | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
-| lucide-react | ISC | @Animatica/editor, @Animatica/web |
-| next | MIT | @Animatica/web |
-| react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| react-dom | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| tailwind-merge | MIT | @Animatica/editor |
-| tailwindcss | MIT | @Animatica/editor |
-| three | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
-| tone | MIT | @Animatica/engine |
-| turbo | MIT | Animatica |
-| typescript | Apache-2.0 | @Animatica/contracts, @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web, Animatica |
-| uuid | MIT | @Animatica/engine |
-| vite | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform |
-| vitest | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| zod | MIT | @Animatica/engine |
-| zundo | MIT | @Animatica/engine |
-| zustand | MIT | @Animatica/engine |
-
-## All Dependencies (including transitive)
-
-<details>
-<summary>Click to expand full dependency list</summary>
-
-| Dependency | Version | License |
-| --- | --- | --- |
-| @acemir/cssom | 0.9.31 | MIT |
-| @adraffy/ens-normalize | 1.10.1 | MIT |
-| @alloc/quick-lru | 5.2.0 | MIT |
-| @asamuzakjp/css-color | 5.0.0 | MIT |
-| @asamuzakjp/dom-selector | 6.8.1 | MIT |
-| @asamuzakjp/nwsapi | 2.3.9 | MIT |
-| @babel/code-frame | 7.29.0 | MIT |
-| @babel/compat-data | 7.29.0 | MIT |
-| @babel/core | 7.29.0 | MIT |
-| @babel/generator | 7.29.1 | MIT |
-| @babel/helper-compilation-targets | 7.28.6 | MIT |
-| @babel/helper-globals | 7.28.0 | MIT |
-| @babel/helper-module-imports | 7.28.6 | MIT |
-| @babel/helper-module-transforms | 7.28.6 | MIT |
-| @babel/helper-plugin-utils | 7.28.6 | MIT |
-| @babel/helper-string-parser | 7.27.1 | MIT |
-| @babel/helper-validator-identifier | 7.28.5 | MIT |
-| @babel/helper-validator-option | 7.27.1 | MIT |
-| @babel/helpers | 7.28.6 | MIT |
-| @babel/parser | 7.29.0 | MIT |
-| @babel/plugin-transform-react-jsx-self | 7.27.1 | MIT |
-| @babel/plugin-transform-react-jsx-source | 7.27.1 | MIT |
-| @babel/runtime | 7.28.6 | MIT |
-| @babel/template | 7.28.6 | MIT |
-| @babel/traverse | 7.29.0 | MIT |
-| @babel/types | 7.29.0 | MIT |
-| @bramus/specificity | 2.4.2 | MIT |
-| @cspotcode/source-map-support | 0.8.1 | MIT |
-| @csstools/color-helpers | 6.0.2 | MIT-0 |
-| @csstools/css-calc | 3.1.1 | MIT |
-| @csstools/css-color-parser | 4.0.2 | MIT |
-| @csstools/css-parser-algorithms | 4.0.0 | MIT |
-| @csstools/css-syntax-patches-for-csstree | 1.0.28 | MIT-0 |
-| @csstools/css-tokenizer | 4.0.0 | MIT |
-| @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 |
-| @esbuild/linux-x64 | 0.27.3 | MIT |
-| @ethereumjs/rlp | 4.0.1 | MPL-2.0 |
-| @ethereumjs/util | 8.1.0 | MPL-2.0 |
-| @ethersproject/abi | 5.8.0 | MIT |
-| @ethersproject/abstract-provider | 5.8.0 | MIT |
-| @ethersproject/abstract-signer | 5.8.0 | MIT |
-| @ethersproject/address | 5.6.1 | MIT |
-| @ethersproject/base64 | 5.8.0 | MIT |
-| @ethersproject/basex | 5.8.0 | MIT |
-| @ethersproject/bignumber | 5.8.0 | MIT |
-| @ethersproject/bytes | 5.8.0 | MIT |
-| @ethersproject/constants | 5.8.0 | MIT |
-| @ethersproject/contracts | 5.8.0 | MIT |
-| @ethersproject/hash | 5.8.0 | MIT |
-| @ethersproject/hdnode | 5.8.0 | MIT |
-| @ethersproject/json-wallets | 5.8.0 | MIT |
-| @ethersproject/keccak256 | 5.8.0 | MIT |
-| @ethersproject/logger | 5.8.0 | MIT |
-| @ethersproject/networks | 5.8.0 | MIT |
-| @ethersproject/pbkdf2 | 5.8.0 | MIT |
-| @ethersproject/properties | 5.8.0 | MIT |
-| @ethersproject/providers | 5.8.0 | MIT |
-| @ethersproject/random | 5.8.0 | MIT |
-| @ethersproject/rlp | 5.8.0 | MIT |
-| @ethersproject/sha2 | 5.8.0 | MIT |
-| @ethersproject/signing-key | 5.8.0 | MIT |
-| @ethersproject/solidity | 5.8.0 | MIT |
-| @ethersproject/strings | 5.8.0 | MIT |
-| @ethersproject/transactions | 5.8.0 | MIT |
-| @ethersproject/units | 5.8.0 | MIT |
-| @ethersproject/wallet | 5.8.0 | MIT |
-| @ethersproject/web | 5.8.0 | MIT |
-| @ethersproject/wordlists | 5.8.0 | MIT |
-| @exodus/bytes | 1.14.1 | MIT |
-| @fastify/busboy | 2.1.1 | MIT |
-| @img/colour | 1.0.0 | MIT |
-| @img/sharp-libvips-linux-x64 | 1.2.4 | LGPL-3.0-or-later |
-| @img/sharp-libvips-linuxmusl-x64 | 1.2.4 | LGPL-3.0-or-later |
-| @img/sharp-linux-x64 | 0.34.5 | Apache-2.0 |
-| @img/sharp-linuxmusl-x64 | 0.34.5 | Apache-2.0 |
-| @jridgewell/gen-mapping | 0.3.13 | MIT |
-| @jridgewell/remapping | 2.3.5 | MIT |
-| @jridgewell/resolve-uri | 3.1.2 | MIT |
-| @jridgewell/sourcemap-codec | 1.5.5 | MIT |
-| @jridgewell/trace-mapping | 0.3.9 | MIT |
-| @mediapipe/tasks-vision | 0.10.17 | Apache-2.0 |
-| @monogrid/gainmap-js | 3.4.0 | MIT |
-| @next/env | 15.5.12 | MIT |
-| @next/swc-linux-x64-gnu | 15.5.12 | MIT |
-| @next/swc-linux-x64-musl | 15.5.12 | MIT |
-| @noble/curves | 1.2.0 | MIT |
-| @noble/hashes | 1.2.0 | MIT |
-| @noble/secp256k1 | 1.7.1 | MIT |
-| @nodelib/fs.scandir | 2.1.5 | MIT |
-| @nodelib/fs.stat | 2.0.5 | MIT |
-| @nodelib/fs.walk | 1.2.8 | MIT |
-| @nomicfoundation/edr | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-darwin-arm64 | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-darwin-x64 | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-linux-arm64-gnu | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-linux-arm64-musl | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-linux-x64-gnu | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-linux-x64-musl | 0.12.0-next.23 | MIT |
-| @nomicfoundation/edr-win32-x64-msvc | 0.12.0-next.23 | MIT |
-| @nomicfoundation/hardhat-chai-matchers | 2.1.0 | MIT |
-| @nomicfoundation/hardhat-ethers | 3.1.3 | MIT |
-| @nomicfoundation/hardhat-ignition | 0.15.16 | MIT |
-| @nomicfoundation/hardhat-ignition-ethers | 0.15.17 | MIT |
-| @nomicfoundation/hardhat-network-helpers | 1.1.2 | MIT |
-| @nomicfoundation/hardhat-toolbox | 5.0.0 | MIT |
-| @nomicfoundation/hardhat-verify | 2.1.3 | MIT |
-| @nomicfoundation/ignition-core | 0.15.15 | MIT |
-| @nomicfoundation/ignition-ui | 0.15.13 | MIT |
-| @nomicfoundation/solidity-analyzer | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-darwin-arm64 | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-darwin-x64 | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-linux-arm64-gnu | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-linux-arm64-musl | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-linux-x64-gnu | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-linux-x64-musl | 0.1.2 | MIT |
-| @nomicfoundation/solidity-analyzer-win32-x64-msvc | 0.1.2 | MIT |
-| @openzeppelin/contracts | 5.4.0 | MIT |
-| @react-three/drei | 10.7.7 | MIT |
-| @react-three/fiber | 9.5.0 | MIT |
-| @rolldown/pluginutils | 1.0.0-rc.3 | MIT |
-| @rollup/rollup-linux-x64-gnu | 4.58.0 | MIT |
-| @rollup/rollup-linux-x64-musl | 4.58.0 | MIT |
-| @scure/base | 1.1.9 | MIT |
-| @scure/bip32 | 1.1.5 | MIT |
-| @scure/bip39 | 1.1.1 | MIT |
-| @sentry/core | 5.30.0 | BSD-3-Clause |
-| @sentry/hub | 5.30.0 | BSD-3-Clause |
-| @sentry/minimal | 5.30.0 | BSD-3-Clause |
-| @sentry/node | 5.30.0 | BSD-3-Clause |
-| @sentry/tracing | 5.30.0 | MIT |
-| @sentry/types | 5.30.0 | BSD-3-Clause |
-| @sentry/utils | 5.30.0 | BSD-3-Clause |
-| @solidity-parser/parser | 0.14.5 | MIT |
-| @standard-schema/spec | 1.1.0 | MIT |
-| @swc/helpers | 0.5.15 | Apache-2.0 |
-| @tailwindcss/node | 4.2.0 | MIT |
-| @tailwindcss/oxide | 4.2.0 | MIT |
-| @tailwindcss/oxide-linux-x64-gnu | 4.2.0 | MIT |
-| @tailwindcss/oxide-linux-x64-musl | 4.2.0 | MIT |
-| @tailwindcss/postcss | 4.2.0 | MIT |
-| @testing-library/dom | 10.4.1 | MIT |
-| @testing-library/react | 16.3.2 | MIT |
-| @tsconfig/node10 | 1.0.12 | MIT |
-| @tsconfig/node12 | 1.0.11 | MIT |
-| @tsconfig/node14 | 1.0.3 | MIT |
-| @tsconfig/node16 | 1.0.4 | MIT |
-| @tweenjs/tween.js | 23.1.3 | MIT |
-| @typechain/ethers-v6 | 0.5.1 | MIT |
-| @typechain/hardhat | 9.1.0 | MIT |
-| @types/aria-query | 5.0.4 | MIT |
-| @types/babel__core | 7.20.5 | MIT |
-| @types/babel__generator | 7.27.0 | MIT |
-| @types/babel__template | 7.4.4 | MIT |
-| @types/babel__traverse | 7.28.0 | MIT |
-| @types/bn.js | 5.2.0 | MIT |
-| @types/chai | 5.2.3 | MIT |
-| @types/chai-as-promised | 7.1.8 | MIT |
-| @types/concat-stream | 1.6.1 | MIT |
-| @types/deep-eql | 4.0.2 | MIT |
-| @types/draco3d | 1.4.10 | MIT |
-| @types/estree | 1.0.8 | MIT |
-| @types/form-data | 0.0.33 | MIT |
-| @types/glob | 7.2.0 | MIT |
-| @types/minimatch | 6.0.0 | MIT |
-| @types/mocha | 10.0.10 | MIT |
-| @types/node | 8.10.66 | MIT |
-| @types/offscreencanvas | 2019.7.3 | MIT |
-| @types/pbkdf2 | 3.1.2 | MIT |
-| @types/prettier | 2.7.3 | MIT |
-| @types/qs | 6.14.0 | MIT |
-| @types/react | 19.2.14 | MIT |
-| @types/react-dom | 19.2.3 | MIT |
-| @types/react-reconciler | 0.28.9 | MIT |
-| @types/secp256k1 | 4.0.7 | MIT |
-| @types/stats.js | 0.17.4 | MIT |
-| @types/three | 0.182.0 | MIT |
-| @types/uuid | 10.0.0 | MIT |
-| @types/webxr | 0.5.24 | MIT |
-| @use-gesture/core | 10.3.1 | MIT |
-| @use-gesture/react | 10.3.1 | MIT |
-| @vitejs/plugin-react | 5.1.4 | MIT |
-| @vitest/expect | 4.0.18 | MIT |
-| @vitest/mocker | 4.0.18 | MIT |
-| @vitest/pretty-format | 4.0.18 | MIT |
-| @vitest/runner | 4.0.18 | MIT |
-| @vitest/snapshot | 4.0.18 | MIT |
-| @vitest/spy | 4.0.18 | MIT |
-| @vitest/utils | 4.0.18 | MIT |
-| @webgpu/types | 0.1.69 | BSD-3-Clause |
-| abbrev | 1.0.9 | ISC |
-| acorn | 8.16.0 | MIT |
-| acorn-walk | 8.3.5 | MIT |
-| adm-zip | 0.4.16 | MIT |
-| aes-js | 3.0.0 | MIT |
-| agent-base | 6.0.2 | MIT |
-| aggregate-error | 3.1.0 | MIT |
-| ajv | 8.18.0 | MIT |
-| amdefine | 1.0.1 | BSD-3-Clause OR MIT |
-| ansi-align | 3.0.1 | ISC |
-| ansi-colors | 4.1.3 | MIT |
-| ansi-escapes | 4.3.2 | MIT |
-| ansi-regex | 3.0.1 | MIT |
-| ansi-styles | 3.2.1 | MIT |
-| antlr4ts | 0.5.0-alpha.4 | BSD-3-Clause |
-| anymatch | 3.1.3 | ISC |
-| arg | 4.1.3 | MIT |
-| argparse | 1.0.10 | MIT |
-| argparse | 2.0.1 | Python-2.0 |
-| aria-query | 5.3.0 | Apache-2.0 |
-| array-back | 3.1.0 | MIT |
-| array-union | 2.1.0 | MIT |
-| array-uniq | 1.0.3 | MIT |
-| asap | 2.0.6 | MIT |
-| assertion-error | 2.0.1 | MIT |
-| astral-regex | 2.0.0 | MIT |
-| async | 1.5.2 | MIT |
-| asynckit | 0.4.0 | MIT |
-| at-least-node | 1.0.0 | ISC |
-| automation-events | 7.1.15 | MIT |
-| available-typed-arrays | 1.0.7 | MIT |
-| axios | 1.13.5 | MIT |
-| balanced-match | 1.0.2 | MIT |
-| base-x | 3.0.11 | MIT |
-| base64-js | 1.5.1 | MIT |
-| baseline-browser-mapping | 2.10.0 | Apache-2.0 |
-| bech32 | 1.1.4 | MIT |
-| bidi-js | 1.0.3 | MIT |
-| binary-extensions | 2.3.0 | MIT |
-| blakejs | 1.2.1 | MIT |
-| bn.js | 4.11.6 | MIT |
-| boxen | 5.1.2 | MIT |
-| brace-expansion | 1.1.12 | MIT |
-| braces | 3.0.3 | MIT |
-| brorand | 1.1.0 | MIT |
-| browser-stdout | 1.3.1 | ISC |
-| browserify-aes | 1.2.0 | MIT |
-| browserslist | 4.28.1 | MIT |
-| bs58 | 4.0.1 | MIT |
-| bs58check | 2.1.2 | MIT |
-| buffer | 6.0.3 | MIT |
-| buffer-from | 1.1.2 | MIT |
-| buffer-xor | 1.0.3 | MIT |
-| bytes | 3.1.2 | MIT |
-| call-bind | 1.0.8 | MIT |
-| call-bind-apply-helpers | 1.0.2 | MIT |
-| call-bound | 1.0.4 | MIT |
-| camelcase | 6.3.0 | MIT |
-| camera-controls | 3.1.2 | MIT |
-| caniuse-lite | 1.0.30001770 | CC-BY-4.0 |
-| caseless | 0.12.0 | Apache-2.0 |
-| cbor | 8.1.0 | MIT |
-| chai | 6.2.2 | MIT |
-| chai-as-promised | 7.1.2 | WTFPL |
-| chalk | 2.4.2 | MIT |
-| charenc | 0.0.2 | BSD-3-Clause |
-| check-error | 1.0.3 | MIT |
-| chokidar | 3.6.0 | MIT |
-| ci-info | 2.0.0 | MIT |
-| cipher-base | 1.0.7 | MIT |
-| clean-stack | 2.2.0 | MIT |
-| cli-boxes | 2.2.1 | MIT |
-| cli-table3 | 0.5.1 | MIT |
-| client-only | 0.0.1 | MIT |
-| cliui | 7.0.4 | ISC |
-| clsx | 2.1.1 | MIT |
-| color-convert | 1.9.3 | MIT |
-| color-name | 1.1.3 | MIT |
-| colors | 1.4.0 | MIT |
-| combined-stream | 1.0.8 | MIT |
-| command-exists | 1.2.9 | MIT |
-| command-line-args | 5.2.1 | MIT |
-| command-line-usage | 6.1.3 | MIT |
-| commander | 8.3.0 | MIT |
-| concat-map | 0.0.1 | MIT |
-| concat-stream | 1.6.2 | MIT |
-| convert-source-map | 2.0.0 | MIT |
-| cookie | 0.4.2 | MIT |
-| core-util-is | 1.0.3 | MIT |
-| create-hash | 1.2.0 | MIT |
-| create-hmac | 1.1.7 | MIT |
-| create-require | 1.1.1 | MIT |
-| cross-env | 7.0.3 | MIT |
-| cross-spawn | 7.0.6 | MIT |
-| crypt | 0.0.2 | BSD-3-Clause |
-| css-tree | 3.1.0 | MIT |
-| cssstyle | 6.1.0 | MIT |
-| csstype | 3.2.3 | MIT |
-| data-urls | 7.0.0 | MIT |
-| death | 1.1.0 | MIT |
-| debug | 4.4.3 | MIT |
-| decamelize | 4.0.0 | MIT |
-| decimal.js | 10.6.0 | MIT |
-| deep-eql | 4.1.4 | MIT |
-| deep-extend | 0.6.0 | MIT |
-| deep-is | 0.1.4 | MIT |
-| define-data-property | 1.1.4 | MIT |
-| delayed-stream | 1.0.0 | MIT |
-| depd | 2.0.0 | MIT |
-| dequal | 2.0.3 | MIT |
-| detect-gpu | 5.0.70 | MIT |
-| detect-libc | 2.1.2 | Apache-2.0 |
-| diff | 4.0.4 | BSD-3-Clause |
-| difflib | 0.2.4 | PSF |
-| dir-glob | 3.0.1 | MIT |
-| dom-accessibility-api | 0.5.16 | MIT |
-| draco3d | 1.5.7 | Apache-2.0 |
-| dunder-proto | 1.0.1 | MIT |
-| electron-to-chromium | 1.5.302 | ISC |
-| elliptic | 6.6.1 | MIT |
-| emoji-regex | 8.0.0 | MIT |
-| enhanced-resolve | 5.19.0 | MIT |
-| enquirer | 2.4.1 | MIT |
-| entities | 6.0.1 | BSD-2-Clause |
-| env-paths | 2.2.1 | MIT |
-| es-define-property | 1.0.1 | MIT |
-| es-errors | 1.3.0 | MIT |
-| es-module-lexer | 1.7.0 | MIT |
-| es-object-atoms | 1.1.1 | MIT |
-| es-set-tostringtag | 2.1.0 | MIT |
-| esbuild | 0.27.3 | MIT |
-| escalade | 3.2.0 | MIT |
-| escape-string-regexp | 1.0.5 | MIT |
-| escodegen | 1.8.1 | BSD-2-Clause |
-| esprima | 2.7.3 | BSD-2-Clause |
-| estraverse | 1.9.3 | BSD |
-| estree-walker | 3.0.3 | MIT |
-| esutils | 2.0.3 | BSD-2-Clause |
-| eth-gas-reporter | 0.2.27 | MIT |
-| ethereum-bloom-filters | 1.2.0 | MIT |
-| ethereum-cryptography | 0.1.3 | MIT |
-| ethereumjs-util | 7.1.5 | MPL-2.0 |
-| ethers | 5.8.0 | MIT |
-| ethjs-unit | 0.1.6 | MIT |
-| evp_bytestokey | 1.0.3 | MIT |
-| expect-type | 1.3.0 | Apache-2.0 |
-| fast-deep-equal | 3.1.3 | MIT |
-| fast-glob | 3.3.3 | MIT |
-| fast-levenshtein | 2.0.6 | MIT |
-| fast-uri | 3.1.0 | BSD-3-Clause |
-| fastq | 1.20.1 | ISC |
-| fdir | 6.5.0 | MIT |
-| fflate | 0.6.10 | MIT |
-| fill-range | 7.1.1 | MIT |
-| find-replace | 3.0.0 | MIT |
-| find-up | 5.0.0 | MIT |
-| flat | 5.0.2 | BSD-3-Clause |
-| follow-redirects | 1.15.11 | MIT |
-| for-each | 0.3.5 | MIT |
-| form-data | 2.5.5 | MIT |
-| fp-ts | 1.19.3 | MIT |
-| fs-extra | 7.0.1 | MIT |
-| fs-readdir-recursive | 1.1.0 | MIT |
-| fs.realpath | 1.0.0 | ISC |
-| function-bind | 1.1.2 | MIT |
-| gensync | 1.0.0-beta.2 | MIT |
-| get-caller-file | 2.0.5 | ISC |
-| get-func-name | 2.0.2 | MIT |
-| get-intrinsic | 1.3.0 | MIT |
-| get-port | 3.2.0 | MIT |
-| get-proto | 1.0.1 | MIT |
-| ghost-testrpc | 0.0.2 | ISC |
-| glob | 5.0.15 | ISC |
-| glob-parent | 5.1.2 | ISC |
-| global-modules | 2.0.0 | MIT |
-| global-prefix | 3.0.0 | MIT |
-| globby | 10.0.2 | MIT |
-| glsl-noise | 0.0.0 | MIT |
-| gopd | 1.2.0 | MIT |
-| graceful-fs | 4.2.11 | ISC |
-| handlebars | 4.7.8 | MIT |
-| hardhat | 2.28.6 | MIT |
-| hardhat-gas-reporter | 1.0.10 | MIT |
-| has-flag | 1.0.0 | MIT |
-| has-property-descriptors | 1.0.2 | MIT |
-| has-symbols | 1.1.0 | MIT |
-| has-tostringtag | 1.0.2 | MIT |
-| hash-base | 3.1.2 | MIT |
-| hash.js | 1.1.7 | MIT |
-| hasown | 2.0.2 | MIT |
-| he | 1.2.0 | MIT |
-| heap | 0.2.7 | MIT |
-| hls.js | 1.6.15 | Apache-2.0 |
-| hmac-drbg | 1.0.1 | MIT |
-| html-encoding-sniffer | 6.0.0 | MIT |
-| http-basic | 8.1.3 | MIT |
-| http-errors | 2.0.1 | MIT |
-| http-proxy-agent | 7.0.2 | MIT |
-| http-response-object | 3.0.2 | MIT |
-| https-proxy-agent | 5.0.1 | MIT |
-| iconv-lite | 0.4.24 | MIT |
-| ieee754 | 1.2.1 | BSD-3-Clause |
-| ignore | 5.3.2 | MIT |
-| immediate | 3.0.6 | MIT |
-| immer | 10.0.2 | MIT |
-| immutable | 4.3.7 | MIT |
-| indent-string | 4.0.0 | MIT |
-| inflight | 1.0.6 | ISC |
-| inherits | 2.0.4 | ISC |
-| ini | 1.3.8 | ISC |
-| interpret | 1.4.0 | MIT |
-| io-ts | 1.10.4 | MIT |
-| is-binary-path | 2.1.0 | MIT |
-| is-callable | 1.2.7 | MIT |
-| is-core-module | 2.16.1 | MIT |
-| is-extglob | 2.1.1 | MIT |
-| is-fullwidth-code-point | 2.0.0 | MIT |
-| is-glob | 4.0.3 | MIT |
-| is-hex-prefixed | 1.0.0 | MIT |
-| is-number | 7.0.0 | MIT |
-| is-plain-obj | 2.1.0 | MIT |
-| is-potential-custom-element-name | 1.0.1 | MIT |
-| is-promise | 2.2.2 | MIT |
-| is-typed-array | 1.1.15 | MIT |
-| is-unicode-supported | 0.1.0 | MIT |
-| isarray | 1.0.0 | MIT |
-| isexe | 2.0.0 | ISC |
-| its-fine | 2.0.0 | MIT |
-| jiti | 2.6.1 | MIT |
-| js-sha3 | 0.8.0 | MIT |
-| js-tokens | 4.0.0 | MIT |
-| js-yaml | 3.14.2 | MIT |
-| jsdom | 28.1.0 | MIT |
-| jsesc | 3.1.0 | MIT |
-| json-schema-traverse | 1.0.0 | MIT |
-| json-stream-stringify | 3.1.6 | MIT |
-| json-stringify-safe | 5.0.1 | ISC |
-| json5 | 2.2.3 | MIT |
-| jsonfile | 4.0.0 | MIT |
-| jsonschema | 1.5.0 | MIT |
-| keccak | 3.0.4 | MIT |
-| kind-of | 6.0.3 | MIT |
-| kleur | 3.0.3 | MIT |
-| levn | 0.3.0 | MIT |
-| lie | 3.3.0 | MIT |
-| lightningcss | 1.31.1 | MPL-2.0 |
-| lightningcss-linux-x64-gnu | 1.31.1 | MPL-2.0 |
-| lightningcss-linux-x64-musl | 1.31.1 | MPL-2.0 |
-| locate-path | 6.0.0 | MIT |
-| lodash | 4.17.21 | MIT |
-| lodash.camelcase | 4.3.0 | MIT |
-| lodash.clonedeep | 4.5.0 | MIT |
-| lodash.isequal | 4.5.0 | MIT |
-| lodash.truncate | 4.4.2 | MIT |
-| log-symbols | 4.1.0 | MIT |
-| lru_map | 0.3.3 | MIT |
-| lru-cache | 5.1.1 | ISC |
-| lru-cache | 11.2.6 | BlueOak-1.0.0 |
-| lucide-react | 0.563.0 | ISC |
-| lz-string | 1.5.0 | MIT |
-| maath | 0.10.8 | MIT |
-| magic-string | 0.30.21 | MIT |
-| make-error | 1.3.6 | ISC |
-| markdown-table | 1.1.3 | MIT |
-| math-intrinsics | 1.1.0 | MIT |
-| md5.js | 1.3.5 | MIT |
-| mdn-data | 2.12.2 | CC0-1.0 |
-| memorystream | 0.3.1 | MIT |
-| merge2 | 1.4.1 | MIT |
-| meshline | 3.3.1 | MIT |
-| meshoptimizer | 0.22.0 | MIT |
-| micro-eth-signer | 0.14.0 | MIT |
-| micro-ftch | 0.3.1 | MIT |
-| micro-packed | 0.7.3 | MIT |
-| micromatch | 4.0.8 | MIT |
-| mime-db | 1.52.0 | MIT |
-| mime-types | 2.1.35 | MIT |
-| minimalistic-assert | 1.0.1 | ISC |
-| minimalistic-crypto-utils | 1.0.1 | MIT |
-| minimatch | 3.1.3 | ISC |
-| minimatch | 10.2.2 | BlueOak-1.0.0 |
-| minimist | 1.2.8 | MIT |
-| mkdirp | 0.5.6 | MIT |
-| mnemonist | 0.38.5 | MIT |
-| mocha | 10.8.2 | MIT |
-| ms | 2.1.3 | MIT |
-| nanoid | 3.3.11 | MIT |
-| ndjson | 2.0.0 | BSD-3-Clause |
-| neo-async | 2.6.2 | MIT |
-| next | 15.5.12 | MIT |
-| node-addon-api | 2.0.2 | MIT |
-| node-emoji | 1.11.0 | MIT |
-| node-gyp-build | 4.8.4 | MIT |
-| node-releases | 2.0.27 | MIT |
-| nofilter | 3.1.0 | MIT |
-| nopt | 3.0.6 | ISC |
-| normalize-path | 3.0.0 | MIT |
-| number-to-bn | 1.7.0 | MIT |
-| object-assign | 4.1.1 | MIT |
-| object-inspect | 1.13.4 | MIT |
-| obliterator | 2.0.5 | MIT |
-| obug | 2.1.1 | MIT |
-| once | 1.4.0 | ISC |
-| optionator | 0.8.3 | MIT |
-| ordinal | 1.0.3 | MIT |
-| os-tmpdir | 1.0.2 | MIT |
-| p-limit | 3.1.0 | MIT |
-| p-locate | 5.0.0 | MIT |
-| p-map | 4.0.0 | MIT |
-| parse-cache-control | 1.0.1 | BSD |
-| parse5 | 8.0.0 | MIT |
-| path-exists | 4.0.0 | MIT |
-| path-is-absolute | 1.0.1 | MIT |
-| path-key | 3.1.1 | MIT |
-| path-parse | 1.0.7 | MIT |
-| path-type | 4.0.0 | MIT |
-| pathe | 2.0.3 | MIT |
-| pbkdf2 | 3.1.5 | MIT |
-| picocolors | 1.1.1 | ISC |
-| picomatch | 2.3.1 | MIT |
-| pify | 4.0.1 | MIT |
-| possible-typed-array-names | 1.1.0 | MIT |
-| postcss | 8.4.31 | MIT |
-| potpack | 1.0.2 | ISC |
-| prelude-ls | 1.1.2 | MIT |
-| prettier | 2.8.8 | MIT |
-| pretty-format | 27.5.1 | MIT |
-| process-nextick-args | 2.0.1 | MIT |
-| promise | 8.3.0 | MIT |
-| promise-worker-transferable | 1.0.4 | Apache-2.0 |
-| prompts | 2.4.2 | MIT |
-| proxy-from-env | 1.1.0 | MIT |
-| punycode | 2.3.1 | MIT |
-| qs | 6.15.0 | BSD-3-Clause |
-| queue-microtask | 1.2.3 | MIT |
-| randombytes | 2.1.0 | MIT |
-| raw-body | 2.5.3 | MIT |
-| react | 19.2.4 | MIT |
-| react-dom | 19.2.4 | MIT |
-| react-is | 17.0.2 | MIT |
-| react-refresh | 0.18.0 | MIT |
-| react-use-measure | 2.1.7 | MIT |
-| readable-stream | 2.3.8 | MIT |
-| readdirp | 3.6.0 | MIT |
-| rechoir | 0.6.2 | MIT |
-| recursive-readdir | 2.2.3 | MIT |
-| reduce-flatten | 2.0.0 | MIT |
-| req-cwd | 2.0.0 | MIT |
-| req-from | 2.0.0 | MIT |
-| require-directory | 2.1.1 | MIT |
-| require-from-string | 2.0.2 | MIT |
-| resolve | 1.1.7 | MIT |
-| resolve-from | 3.0.0 | MIT |
-| reusify | 1.1.0 | MIT |
-| ripemd160 | 2.0.3 | MIT |
-| rlp | 2.2.7 | MPL-2.0 |
-| rollup | 4.58.0 | MIT |
-| run-parallel | 1.2.0 | MIT |
-| safe-buffer | 5.1.2 | MIT |
-| safer-buffer | 2.1.2 | MIT |
-| saxes | 6.0.0 | ISC |
-| sc-istanbul | 0.4.6 | BSD-3-Clause |
-| scheduler | 0.27.0 | MIT |
-| scrypt-js | 3.0.1 | MIT |
-| secp256k1 | 4.0.4 | MIT |
-| semver | 5.7.2 | ISC |
-| serialize-javascript | 6.0.2 | BSD-3-Clause |
-| set-function-length | 1.2.2 | MIT |
-| setimmediate | 1.0.5 | MIT |
-| setprototypeof | 1.2.0 | ISC |
-| sha.js | 2.4.12 | (MIT AND BSD-3-Clause) |
-| sha1 | 1.1.1 | BSD-3-Clause |
-| sharp | 0.34.5 | Apache-2.0 |
-| shebang-command | 2.0.0 | MIT |
-| shebang-regex | 3.0.0 | MIT |
-| shelljs | 0.8.5 | BSD-3-Clause |
-| side-channel | 1.1.0 | MIT |
-| side-channel-list | 1.0.0 | MIT |
-| side-channel-map | 1.0.1 | MIT |
-| side-channel-weakmap | 1.0.2 | MIT |
-| siginfo | 2.0.0 | ISC |
-| sisteransi | 1.0.5 | MIT |
-| slash | 3.0.0 | MIT |
-| slice-ansi | 4.0.0 | MIT |
-| solc | 0.8.26 | MIT |
-| solidity-coverage | 0.8.17 | ISC |
-| source-map | 0.6.1 | BSD-3-Clause |
-| source-map | 0.2.0 | BSD |
-| source-map-js | 1.2.1 | BSD-3-Clause |
-| source-map-support | 0.5.21 | MIT |
-| split2 | 3.2.2 | ISC |
-| sprintf-js | 1.0.3 | BSD-3-Clause |
-| stackback | 0.0.2 | MIT |
-| stacktrace-parser | 0.1.11 | MIT |
-| standardized-audio-context | 25.3.77 | MIT |
-| stats-gl | 2.4.2 | MIT |
-| stats.js | 0.17.0 | MIT |
-| statuses | 2.0.2 | MIT |
-| std-env | 3.10.0 | MIT |
-| string_decoder | 1.1.1 | MIT |
-| string-format | 2.0.0 | WTFPL OR MIT |
-| string-width | 2.1.1 | MIT |
-| strip-ansi | 4.0.0 | MIT |
-| strip-hex-prefix | 1.0.0 | MIT |
-| strip-json-comments | 3.1.1 | MIT |
-| styled-jsx | 5.1.6 | MIT |
-| supports-color | 3.2.3 | MIT |
-| supports-preserve-symlinks-flag | 1.0.0 | MIT |
-| suspend-react | 0.1.3 | MIT |
-| symbol-tree | 3.2.4 | MIT |
-| sync-request | 6.1.0 | MIT |
-| sync-rpc | 1.3.6 | MIT |
-| table | 6.9.0 | BSD-3-Clause |
-| table-layout | 1.0.2 | MIT |
-| tailwind-merge | 3.5.0 | MIT |
-| tailwindcss | 4.2.0 | MIT |
-| tapable | 2.3.0 | MIT |
-| then-request | 6.0.2 | MIT |
-| three | 0.182.0 | MIT |
-| three-mesh-bvh | 0.8.3 | MIT |
-| three-stdlib | 2.36.1 | MIT |
-| through2 | 4.0.2 | MIT |
-| tinybench | 2.9.0 | MIT |
-| tinyexec | 1.0.2 | MIT |
-| tinyglobby | 0.2.15 | MIT |
-| tinyrainbow | 3.0.3 | MIT |
-| tldts | 7.0.23 | MIT |
-| tldts-core | 7.0.23 | MIT |
-| tmp | 0.0.33 | MIT |
-| to-buffer | 1.2.2 | MIT |
-| to-regex-range | 5.0.1 | MIT |
-| toidentifier | 1.0.1 | MIT |
-| tone | 15.1.22 | MIT |
-| tough-cookie | 6.0.0 | BSD-3-Clause |
-| tr46 | 6.0.0 | MIT |
-| troika-three-text | 0.52.4 | MIT |
-| troika-three-utils | 0.52.4 | MIT |
-| troika-worker-utils | 0.52.0 | MIT |
-| ts-command-line-args | 2.5.1 | ISC |
-| ts-essentials | 7.0.3 | MIT |
-| ts-node | 10.9.2 | MIT |
-| tslib | 1.14.1 | 0BSD |
-| tsort | 0.0.1 | MIT |
-| tunnel-rat | 0.1.2 | MIT |
-| turbo | 2.8.10 | MIT |
-| turbo-linux-64 | 2.8.10 | MIT |
-| type-check | 0.3.2 | MIT |
-| type-detect | 4.1.0 | MIT |
-| type-fest | 0.7.1 | (MIT OR CC0-1.0) |
-| typechain | 8.3.2 | MIT |
-| typed-array-buffer | 1.0.3 | MIT |
-| typedarray | 0.0.6 | MIT |
-| typescript | 5.9.3 | Apache-2.0 |
-| typical | 4.0.0 | MIT |
-| uglify-js | 3.19.3 | BSD-2-Clause |
-| undici | 5.29.0 | MIT |
-| undici-types | 6.19.8 | MIT |
-| universalify | 0.1.2 | MIT |
-| unpipe | 1.0.0 | MIT |
-| update-browserslist-db | 1.2.3 | MIT |
-| use-sync-external-store | 1.6.0 | MIT |
-| utf8 | 3.0.0 | MIT |
-| util-deprecate | 1.0.2 | MIT |
-| utility-types | 3.11.0 | MIT |
-| uuid | 8.3.2 | MIT |
-| v8-compile-cache-lib | 3.0.1 | MIT |
-| vite | 7.3.1 | MIT |
-| vitest | 4.0.18 | MIT |
-| w3c-xmlserializer | 5.0.0 | MIT |
-| web3-utils | 1.10.4 | LGPL-3.0 |
-| webgl-constants | 1.1.1 | MIT |
-| webgl-sdf-generator | 1.1.1 | MIT |
-| webidl-conversions | 8.0.1 | BSD-2-Clause |
-| whatwg-mimetype | 5.0.0 | MIT |
-| whatwg-url | 16.0.1 | MIT |
-| which | 1.3.1 | ISC |
-| which-typed-array | 1.1.20 | MIT |
-| why-is-node-running | 2.3.0 | MIT |
-| widest-line | 3.1.0 | MIT |
-| word-wrap | 1.2.5 | MIT |
-| wordwrap | 1.0.0 | MIT |
-| wordwrapjs | 4.0.1 | MIT |
-| workerpool | 6.5.1 | Apache-2.0 |
-| wrap-ansi | 7.0.0 | MIT |
-| wrappy | 1.0.2 | ISC |
-| ws | 7.5.10 | MIT |
-| xml-name-validator | 5.0.0 | Apache-2.0 |
-| xmlchars | 2.2.0 | MIT |
-| y18n | 5.0.8 | ISC |
-| yallist | 3.1.1 | ISC |
-| yargs | 16.2.0 | MIT |
-| yargs-parser | 20.2.9 | ISC |
-| yargs-unparser | 2.0.0 | MIT |
-| yn | 3.1.1 | MIT |
-| yocto-queue | 0.1.0 | MIT |
-| zod | 4.3.6 | MIT |
-| zundo | 2.3.0 | MIT |
-| zustand | 4.5.7 | MIT |
-
-</details>
+| Dependency | License | Type | Used In |
+| --- | --- | --- | --- |
+| @acemir/cssom | MIT | Transitive |  |
+| @adraffy/ens-normalize | MIT | Transitive |  |
+| @alloc/quick-lru | MIT | Transitive |  |
+| @Animatica/contracts | MIT | Workspace | Internal |
+| @Animatica/editor | MIT | Workspace | Internal |
+| @Animatica/engine | MIT | Workspace | Internal |
+| @Animatica/platform | MIT | Workspace | Internal |
+| @Animatica/web | MIT | Workspace | Internal |
+| @asamuzakjp/css-color | MIT | Transitive |  |
+| @asamuzakjp/dom-selector | MIT | Transitive |  |
+| @asamuzakjp/nwsapi | MIT | Transitive |  |
+| @babel/code-frame | MIT | Transitive |  |
+| @babel/compat-data | MIT | Transitive |  |
+| @babel/core | MIT | Transitive |  |
+| @babel/generator | MIT | Transitive |  |
+| @babel/helper-compilation-targets | MIT | Transitive |  |
+| @babel/helper-globals | MIT | Transitive |  |
+| @babel/helper-module-imports | MIT | Transitive |  |
+| @babel/helper-module-transforms | MIT | Transitive |  |
+| @babel/helper-plugin-utils | MIT | Transitive |  |
+| @babel/helper-string-parser | MIT | Transitive |  |
+| @babel/helper-validator-identifier | MIT | Transitive |  |
+| @babel/helper-validator-option | MIT | Transitive |  |
+| @babel/helpers | MIT | Transitive |  |
+| @babel/parser | MIT | Transitive |  |
+| @babel/plugin-transform-react-jsx-self | MIT | Transitive |  |
+| @babel/plugin-transform-react-jsx-source | MIT | Transitive |  |
+| @babel/runtime | MIT | Transitive |  |
+| @babel/template | MIT | Transitive |  |
+| @babel/traverse | MIT | Transitive |  |
+| @babel/types | MIT | Transitive |  |
+| @bramus/specificity | MIT | Transitive |  |
+| @cspotcode/source-map-support | MIT | Transitive |  |
+| @csstools/color-helpers | MIT-0 | Transitive |  |
+| @csstools/css-calc | MIT | Transitive |  |
+| @csstools/css-color-parser | MIT | Transitive |  |
+| @csstools/css-parser-algorithms | MIT | Transitive |  |
+| @csstools/css-syntax-patches-for-csstree | MIT-0 | Transitive |  |
+| @csstools/css-tokenizer | MIT | Transitive |  |
+| @dimforge/rapier3d-compat | Apache-2.0 | Transitive |  |
+| @esbuild/linux-x64 | MIT | Transitive |  |
+| @ethereumjs/rlp | MPL-2.0 | Transitive |  |
+| @ethereumjs/util | MPL-2.0 | Transitive |  |
+| @ethersproject/abi | MIT | Transitive |  |
+| @ethersproject/abstract-provider | MIT | Transitive |  |
+| @ethersproject/abstract-signer | MIT | Transitive |  |
+| @ethersproject/address | MIT | Transitive |  |
+| @ethersproject/base64 | MIT | Transitive |  |
+| @ethersproject/basex | MIT | Transitive |  |
+| @ethersproject/bignumber | MIT | Transitive |  |
+| @ethersproject/bytes | MIT | Transitive |  |
+| @ethersproject/constants | MIT | Transitive |  |
+| @ethersproject/contracts | MIT | Transitive |  |
+| @ethersproject/hash | MIT | Transitive |  |
+| @ethersproject/hdnode | MIT | Transitive |  |
+| @ethersproject/json-wallets | MIT | Transitive |  |
+| @ethersproject/keccak256 | MIT | Transitive |  |
+| @ethersproject/logger | MIT | Transitive |  |
+| @ethersproject/networks | MIT | Transitive |  |
+| @ethersproject/pbkdf2 | MIT | Transitive |  |
+| @ethersproject/properties | MIT | Transitive |  |
+| @ethersproject/providers | MIT | Transitive |  |
+| @ethersproject/random | MIT | Transitive |  |
+| @ethersproject/rlp | MIT | Transitive |  |
+| @ethersproject/sha2 | MIT | Transitive |  |
+| @ethersproject/signing-key | MIT | Transitive |  |
+| @ethersproject/solidity | MIT | Transitive |  |
+| @ethersproject/strings | MIT | Transitive |  |
+| @ethersproject/transactions | MIT | Transitive |  |
+| @ethersproject/units | MIT | Transitive |  |
+| @ethersproject/wallet | MIT | Transitive |  |
+| @ethersproject/web | MIT | Transitive |  |
+| @ethersproject/wordlists | MIT | Transitive |  |
+| @exodus/bytes | MIT | Transitive |  |
+| @fastify/busboy | MIT | Transitive |  |
+| @img/colour | MIT | Transitive |  |
+| @img/sharp-libvips-linux-x64 | LGPL-3.0-or-later | Transitive |  |
+| @img/sharp-libvips-linuxmusl-x64 | LGPL-3.0-or-later | Transitive |  |
+| @img/sharp-linux-x64 | Apache-2.0 | Transitive |  |
+| @img/sharp-linuxmusl-x64 | Apache-2.0 | Transitive |  |
+| @jridgewell/gen-mapping | MIT | Transitive |  |
+| @jridgewell/remapping | MIT | Transitive |  |
+| @jridgewell/resolve-uri | MIT | Transitive |  |
+| @jridgewell/sourcemap-codec | MIT | Transitive |  |
+| @jridgewell/trace-mapping | MIT | Transitive |  |
+| @mediapipe/tasks-vision | Apache-2.0 | Transitive |  |
+| @monogrid/gainmap-js | MIT | Transitive |  |
+| @next/env | MIT | Transitive |  |
+| @next/swc-linux-x64-gnu | MIT | Transitive |  |
+| @next/swc-linux-x64-musl | MIT | Transitive |  |
+| @noble/curves | MIT | Transitive |  |
+| @noble/hashes | MIT | Transitive |  |
+| @noble/secp256k1 | MIT | Transitive |  |
+| @nodelib/fs.scandir | MIT | Transitive |  |
+| @nodelib/fs.stat | MIT | Transitive |  |
+| @nodelib/fs.walk | MIT | Transitive |  |
+| @nomicfoundation/edr | MIT | Transitive |  |
+| @nomicfoundation/edr-darwin-arm64 | MIT | Transitive |  |
+| @nomicfoundation/edr-darwin-x64 | MIT | Transitive |  |
+| @nomicfoundation/edr-linux-arm64-gnu | MIT | Transitive |  |
+| @nomicfoundation/edr-linux-arm64-musl | MIT | Transitive |  |
+| @nomicfoundation/edr-linux-x64-gnu | MIT | Transitive |  |
+| @nomicfoundation/edr-linux-x64-musl | MIT | Transitive |  |
+| @nomicfoundation/edr-win32-x64-msvc | MIT | Transitive |  |
+| @nomicfoundation/hardhat-chai-matchers | MIT | Transitive |  |
+| @nomicfoundation/hardhat-ethers | MIT | Transitive |  |
+| @nomicfoundation/hardhat-ignition | MIT | Transitive |  |
+| @nomicfoundation/hardhat-ignition-ethers | MIT | Transitive |  |
+| @nomicfoundation/hardhat-network-helpers | MIT | Transitive |  |
+| @nomicfoundation/hardhat-toolbox | MIT | Direct | @Animatica/contracts |
+| @nomicfoundation/hardhat-verify | MIT | Transitive |  |
+| @nomicfoundation/ignition-core | MIT | Transitive |  |
+| @nomicfoundation/ignition-ui | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-darwin-arm64 | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-darwin-x64 | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-linux-arm64-gnu | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-linux-arm64-musl | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-linux-x64-gnu | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-linux-x64-musl | MIT | Transitive |  |
+| @nomicfoundation/solidity-analyzer-win32-x64-msvc | MIT | Transitive |  |
+| @openzeppelin/contracts | MIT | Direct | @Animatica/contracts |
+| @react-three/drei | MIT | Direct | @Animatica/editor, @Animatica/engine |
+| @react-three/fiber | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/web |
+| @rolldown/pluginutils | MIT | Transitive |  |
+| @rollup/rollup-linux-x64-gnu | MIT | Transitive |  |
+| @rollup/rollup-linux-x64-musl | MIT | Transitive |  |
+| @scure/base | MIT | Transitive |  |
+| @scure/bip32 | MIT | Transitive |  |
+| @scure/bip39 | MIT | Transitive |  |
+| @sentry/core | BSD-3-Clause | Transitive |  |
+| @sentry/hub | BSD-3-Clause | Transitive |  |
+| @sentry/minimal | BSD-3-Clause | Transitive |  |
+| @sentry/node | BSD-3-Clause | Transitive |  |
+| @sentry/tracing | MIT | Transitive |  |
+| @sentry/types | BSD-3-Clause | Transitive |  |
+| @sentry/utils | BSD-3-Clause | Transitive |  |
+| @solidity-parser/parser | MIT | Transitive |  |
+| @standard-schema/spec | MIT | Transitive |  |
+| @swc/helpers | Apache-2.0 | Transitive |  |
+| @tailwindcss/node | MIT | Transitive |  |
+| @tailwindcss/oxide | MIT | Transitive |  |
+| @tailwindcss/oxide-linux-x64-gnu | MIT | Transitive |  |
+| @tailwindcss/oxide-linux-x64-musl | MIT | Transitive |  |
+| @tailwindcss/postcss | MIT | Direct | @Animatica/editor |
+| @testing-library/dom | MIT | Direct | @Animatica/web |
+| @testing-library/react | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/web |
+| @tsconfig/node10 | MIT | Transitive |  |
+| @tsconfig/node12 | MIT | Transitive |  |
+| @tsconfig/node14 | MIT | Transitive |  |
+| @tsconfig/node16 | MIT | Transitive |  |
+| @tweenjs/tween.js | MIT | Transitive |  |
+| @typechain/ethers-v6 | MIT | Transitive |  |
+| @typechain/hardhat | MIT | Transitive |  |
+| @types/aria-query | MIT | Transitive |  |
+| @types/babel__core | MIT | Transitive |  |
+| @types/babel__generator | MIT | Transitive |  |
+| @types/babel__template | MIT | Transitive |  |
+| @types/babel__traverse | MIT | Transitive |  |
+| @types/bn.js | MIT | Transitive |  |
+| @types/chai | MIT | Transitive |  |
+| @types/chai-as-promised | MIT | Transitive |  |
+| @types/concat-stream | MIT | Transitive |  |
+| @types/deep-eql | MIT | Transitive |  |
+| @types/draco3d | MIT | Transitive |  |
+| @types/estree | MIT | Transitive |  |
+| @types/form-data | MIT | Transitive |  |
+| @types/glob | MIT | Transitive |  |
+| @types/minimatch | MIT | Transitive |  |
+| @types/mocha | MIT | Transitive |  |
+| @types/node | MIT | Direct | @Animatica/engine |
+| @types/offscreencanvas | MIT | Transitive |  |
+| @types/pbkdf2 | MIT | Transitive |  |
+| @types/prettier | MIT | Transitive |  |
+| @types/qs | MIT | Transitive |  |
+| @types/react | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
+| @types/react-dom | MIT | Direct | @Animatica/editor, @Animatica/platform, @Animatica/web |
+| @types/react-reconciler | MIT | Transitive |  |
+| @types/secp256k1 | MIT | Transitive |  |
+| @types/stats.js | MIT | Transitive |  |
+| @types/three | MIT | Direct | @Animatica/editor, @Animatica/engine |
+| @types/uuid | MIT | Direct | @Animatica/engine |
+| @types/webxr | MIT | Transitive |  |
+| @use-gesture/core | MIT | Transitive |  |
+| @use-gesture/react | MIT | Transitive |  |
+| @vitejs/plugin-react | MIT | Direct | @Animatica/editor |
+| @vitest/expect | MIT | Transitive |  |
+| @vitest/mocker | MIT | Transitive |  |
+| @vitest/pretty-format | MIT | Transitive |  |
+| @vitest/runner | MIT | Transitive |  |
+| @vitest/snapshot | MIT | Transitive |  |
+| @vitest/spy | MIT | Transitive |  |
+| @vitest/utils | MIT | Transitive |  |
+| @webgpu/types | BSD-3-Clause | Transitive |  |
+| abbrev | ISC | Transitive |  |
+| acorn | MIT | Transitive |  |
+| acorn-walk | MIT | Transitive |  |
+| adm-zip | MIT | Transitive |  |
+| aes-js | MIT | Transitive |  |
+| agent-base | MIT | Transitive |  |
+| aggregate-error | MIT | Transitive |  |
+| ajv | MIT | Transitive |  |
+| amdefine | BSD-3-Clause OR MIT | Transitive |  |
+| Animatica | MIT | Workspace | Internal |
+| ansi-align | ISC | Transitive |  |
+| ansi-colors | MIT | Transitive |  |
+| ansi-escapes | MIT | Transitive |  |
+| ansi-regex | MIT | Transitive |  |
+| ansi-styles | MIT | Transitive |  |
+| antlr4ts | BSD-3-Clause | Transitive |  |
+| anymatch | ISC | Transitive |  |
+| arg | MIT | Transitive |  |
+| argparse | MIT | Transitive |  |
+| argparse | Python-2.0 | Transitive |  |
+| aria-query | Apache-2.0 | Transitive |  |
+| array-back | MIT | Transitive |  |
+| array-union | MIT | Transitive |  |
+| array-uniq | MIT | Transitive |  |
+| asap | MIT | Transitive |  |
+| assertion-error | MIT | Transitive |  |
+| astral-regex | MIT | Transitive |  |
+| async | MIT | Transitive |  |
+| asynckit | MIT | Transitive |  |
+| at-least-node | ISC | Transitive |  |
+| automation-events | MIT | Transitive |  |
+| available-typed-arrays | MIT | Transitive |  |
+| axios | MIT | Transitive |  |
+| balanced-match | MIT | Transitive |  |
+| base-x | MIT | Transitive |  |
+| base64-js | MIT | Transitive |  |
+| baseline-browser-mapping | Apache-2.0 | Transitive |  |
+| bech32 | MIT | Transitive |  |
+| bidi-js | MIT | Transitive |  |
+| binary-extensions | MIT | Transitive |  |
+| blakejs | MIT | Transitive |  |
+| bn.js | MIT | Transitive |  |
+| boxen | MIT | Transitive |  |
+| brace-expansion | MIT | Transitive |  |
+| braces | MIT | Transitive |  |
+| brorand | MIT | Transitive |  |
+| browser-stdout | ISC | Transitive |  |
+| browserify-aes | MIT | Transitive |  |
+| browserslist | MIT | Transitive |  |
+| bs58 | MIT | Transitive |  |
+| bs58check | MIT | Transitive |  |
+| buffer | MIT | Transitive |  |
+| buffer-from | MIT | Transitive |  |
+| buffer-xor | MIT | Transitive |  |
+| bytes | MIT | Transitive |  |
+| call-bind | MIT | Transitive |  |
+| call-bind-apply-helpers | MIT | Transitive |  |
+| call-bound | MIT | Transitive |  |
+| camelcase | MIT | Transitive |  |
+| camera-controls | MIT | Transitive |  |
+| caniuse-lite | CC-BY-4.0 | Transitive |  |
+| caseless | Apache-2.0 | Transitive |  |
+| cbor | MIT | Transitive |  |
+| chai | MIT | Transitive |  |
+| chai-as-promised | WTFPL | Transitive |  |
+| chalk | MIT | Transitive |  |
+| charenc | BSD-3-Clause | Transitive |  |
+| check-error | MIT | Transitive |  |
+| chokidar | MIT | Transitive |  |
+| ci-info | MIT | Transitive |  |
+| cipher-base | MIT | Transitive |  |
+| clean-stack | MIT | Transitive |  |
+| cli-boxes | MIT | Transitive |  |
+| cli-table3 | MIT | Transitive |  |
+| client-only | MIT | Transitive |  |
+| cliui | ISC | Transitive |  |
+| clsx | MIT | Direct | @Animatica/editor |
+| color-convert | MIT | Transitive |  |
+| color-name | MIT | Transitive |  |
+| colors | MIT | Transitive |  |
+| combined-stream | MIT | Transitive |  |
+| command-exists | MIT | Transitive |  |
+| command-line-args | MIT | Transitive |  |
+| command-line-usage | MIT | Transitive |  |
+| commander | MIT | Transitive |  |
+| concat-map | MIT | Transitive |  |
+| concat-stream | MIT | Transitive |  |
+| convert-source-map | MIT | Transitive |  |
+| cookie | MIT | Transitive |  |
+| core-util-is | MIT | Transitive |  |
+| create-hash | MIT | Transitive |  |
+| create-hmac | MIT | Transitive |  |
+| create-require | MIT | Transitive |  |
+| cross-env | MIT | Transitive |  |
+| cross-spawn | MIT | Transitive |  |
+| crypt | BSD-3-Clause | Transitive |  |
+| css-tree | MIT | Transitive |  |
+| cssstyle | MIT | Transitive |  |
+| csstype | MIT | Transitive |  |
+| data-urls | MIT | Transitive |  |
+| death | MIT | Transitive |  |
+| debug | MIT | Transitive |  |
+| decamelize | MIT | Transitive |  |
+| decimal.js | MIT | Transitive |  |
+| deep-eql | MIT | Transitive |  |
+| deep-extend | MIT | Transitive |  |
+| deep-is | MIT | Transitive |  |
+| define-data-property | MIT | Transitive |  |
+| delayed-stream | MIT | Transitive |  |
+| depd | MIT | Transitive |  |
+| dequal | MIT | Transitive |  |
+| detect-gpu | MIT | Transitive |  |
+| detect-libc | Apache-2.0 | Transitive |  |
+| diff | BSD-3-Clause | Transitive |  |
+| difflib | PSF | Transitive |  |
+| dir-glob | MIT | Transitive |  |
+| dom-accessibility-api | MIT | Transitive |  |
+| draco3d | Apache-2.0 | Transitive |  |
+| dunder-proto | MIT | Transitive |  |
+| electron-to-chromium | ISC | Transitive |  |
+| elliptic | MIT | Transitive |  |
+| emoji-regex | MIT | Transitive |  |
+| enhanced-resolve | MIT | Transitive |  |
+| enquirer | MIT | Transitive |  |
+| entities | BSD-2-Clause | Transitive |  |
+| env-paths | MIT | Transitive |  |
+| es-define-property | MIT | Transitive |  |
+| es-errors | MIT | Transitive |  |
+| es-module-lexer | MIT | Transitive |  |
+| es-object-atoms | MIT | Transitive |  |
+| es-set-tostringtag | MIT | Transitive |  |
+| esbuild | MIT | Transitive |  |
+| escalade | MIT | Transitive |  |
+| escape-string-regexp | MIT | Transitive |  |
+| escodegen | BSD-2-Clause | Transitive |  |
+| esprima | BSD-2-Clause | Transitive |  |
+| estraverse | BSD | Transitive |  |
+| estree-walker | MIT | Transitive |  |
+| esutils | BSD-2-Clause | Transitive |  |
+| eth-gas-reporter | MIT | Transitive |  |
+| ethereum-bloom-filters | MIT | Transitive |  |
+| ethereum-cryptography | MIT | Transitive |  |
+| ethereumjs-util | MPL-2.0 | Transitive |  |
+| ethers | MIT | Transitive |  |
+| ethjs-unit | MIT | Transitive |  |
+| evp_bytestokey | MIT | Transitive |  |
+| expect-type | Apache-2.0 | Transitive |  |
+| fast-deep-equal | MIT | Transitive |  |
+| fast-glob | MIT | Transitive |  |
+| fast-levenshtein | MIT | Transitive |  |
+| fast-uri | BSD-3-Clause | Transitive |  |
+| fastq | ISC | Transitive |  |
+| fdir | MIT | Transitive |  |
+| fflate | MIT | Transitive |  |
+| fill-range | MIT | Transitive |  |
+| find-replace | MIT | Transitive |  |
+| find-up | MIT | Transitive |  |
+| flat | BSD-3-Clause | Transitive |  |
+| follow-redirects | MIT | Transitive |  |
+| for-each | MIT | Transitive |  |
+| form-data | MIT | Transitive |  |
+| fp-ts | MIT | Transitive |  |
+| fs-extra | MIT | Transitive |  |
+| fs-readdir-recursive | MIT | Transitive |  |
+| fs.realpath | ISC | Transitive |  |
+| function-bind | MIT | Transitive |  |
+| gensync | MIT | Transitive |  |
+| get-caller-file | ISC | Transitive |  |
+| get-func-name | MIT | Transitive |  |
+| get-intrinsic | MIT | Transitive |  |
+| get-port | MIT | Transitive |  |
+| get-proto | MIT | Transitive |  |
+| ghost-testrpc | ISC | Transitive |  |
+| glob | ISC | Transitive |  |
+| glob-parent | ISC | Transitive |  |
+| global-modules | MIT | Transitive |  |
+| global-prefix | MIT | Transitive |  |
+| globby | MIT | Transitive |  |
+| glsl-noise | MIT | Transitive |  |
+| gopd | MIT | Transitive |  |
+| graceful-fs | ISC | Transitive |  |
+| handlebars | MIT | Transitive |  |
+| hardhat | MIT | Direct | @Animatica/contracts |
+| hardhat-gas-reporter | MIT | Transitive |  |
+| has-flag | MIT | Transitive |  |
+| has-property-descriptors | MIT | Transitive |  |
+| has-symbols | MIT | Transitive |  |
+| has-tostringtag | MIT | Transitive |  |
+| hash-base | MIT | Transitive |  |
+| hash.js | MIT | Transitive |  |
+| hasown | MIT | Transitive |  |
+| he | MIT | Transitive |  |
+| heap | MIT | Transitive |  |
+| hls.js | Apache-2.0 | Transitive |  |
+| hmac-drbg | MIT | Transitive |  |
+| html-encoding-sniffer | MIT | Transitive |  |
+| http-basic | MIT | Transitive |  |
+| http-errors | MIT | Transitive |  |
+| http-proxy-agent | MIT | Transitive |  |
+| http-response-object | MIT | Transitive |  |
+| https-proxy-agent | MIT | Transitive |  |
+| iconv-lite | MIT | Transitive |  |
+| ieee754 | BSD-3-Clause | Transitive |  |
+| ignore | MIT | Transitive |  |
+| immediate | MIT | Transitive |  |
+| immer | MIT | Direct | @Animatica/engine |
+| immutable | MIT | Transitive |  |
+| indent-string | MIT | Transitive |  |
+| inflight | ISC | Transitive |  |
+| inherits | ISC | Transitive |  |
+| ini | ISC | Transitive |  |
+| interpret | MIT | Transitive |  |
+| io-ts | MIT | Transitive |  |
+| is-binary-path | MIT | Transitive |  |
+| is-callable | MIT | Transitive |  |
+| is-core-module | MIT | Transitive |  |
+| is-extglob | MIT | Transitive |  |
+| is-fullwidth-code-point | MIT | Transitive |  |
+| is-glob | MIT | Transitive |  |
+| is-hex-prefixed | MIT | Transitive |  |
+| is-number | MIT | Transitive |  |
+| is-plain-obj | MIT | Transitive |  |
+| is-potential-custom-element-name | MIT | Transitive |  |
+| is-promise | MIT | Transitive |  |
+| is-typed-array | MIT | Transitive |  |
+| is-unicode-supported | MIT | Transitive |  |
+| isarray | MIT | Transitive |  |
+| isexe | ISC | Transitive |  |
+| its-fine | MIT | Transitive |  |
+| jiti | MIT | Transitive |  |
+| js-sha3 | MIT | Transitive |  |
+| js-tokens | MIT | Transitive |  |
+| js-yaml | MIT | Transitive |  |
+| jsdom | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/web |
+| jsesc | MIT | Transitive |  |
+| json-schema-traverse | MIT | Transitive |  |
+| json-stream-stringify | MIT | Transitive |  |
+| json-stringify-safe | ISC | Transitive |  |
+| json5 | MIT | Transitive |  |
+| jsonfile | MIT | Transitive |  |
+| jsonschema | MIT | Transitive |  |
+| keccak | MIT | Transitive |  |
+| kind-of | MIT | Transitive |  |
+| kleur | MIT | Transitive |  |
+| levn | MIT | Transitive |  |
+| lie | MIT | Transitive |  |
+| lightningcss | MPL-2.0 | Transitive |  |
+| lightningcss-linux-x64-gnu | MPL-2.0 | Transitive |  |
+| lightningcss-linux-x64-musl | MPL-2.0 | Transitive |  |
+| locate-path | MIT | Transitive |  |
+| lodash | MIT | Transitive |  |
+| lodash.camelcase | MIT | Transitive |  |
+| lodash.clonedeep | MIT | Transitive |  |
+| lodash.isequal | MIT | Transitive |  |
+| lodash.truncate | MIT | Transitive |  |
+| log-symbols | MIT | Transitive |  |
+| lru-cache | ISC | Transitive |  |
+| lru-cache | BlueOak-1.0.0 | Transitive |  |
+| lru_map | MIT | Transitive |  |
+| lucide-react | ISC | Direct | @Animatica/editor, @Animatica/web |
+| lz-string | MIT | Transitive |  |
+| maath | MIT | Transitive |  |
+| magic-string | MIT | Transitive |  |
+| make-error | ISC | Transitive |  |
+| markdown-table | MIT | Transitive |  |
+| math-intrinsics | MIT | Transitive |  |
+| md5.js | MIT | Transitive |  |
+| mdn-data | CC0-1.0 | Transitive |  |
+| memorystream | MIT | Transitive |  |
+| merge2 | MIT | Transitive |  |
+| meshline | MIT | Transitive |  |
+| meshoptimizer | MIT | Transitive |  |
+| micro-eth-signer | MIT | Transitive |  |
+| micro-ftch | MIT | Transitive |  |
+| micro-packed | MIT | Transitive |  |
+| micromatch | MIT | Transitive |  |
+| mime-db | MIT | Transitive |  |
+| mime-types | MIT | Transitive |  |
+| minimalistic-assert | ISC | Transitive |  |
+| minimalistic-crypto-utils | MIT | Transitive |  |
+| minimatch | ISC | Transitive |  |
+| minimatch | BlueOak-1.0.0 | Transitive |  |
+| minimist | MIT | Transitive |  |
+| mkdirp | MIT | Transitive |  |
+| mnemonist | MIT | Transitive |  |
+| mocha | MIT | Transitive |  |
+| ms | MIT | Transitive |  |
+| nanoid | MIT | Transitive |  |
+| ndjson | BSD-3-Clause | Transitive |  |
+| neo-async | MIT | Transitive |  |
+| next | MIT | Direct | @Animatica/web |
+| node-addon-api | MIT | Transitive |  |
+| node-emoji | MIT | Transitive |  |
+| node-gyp-build | MIT | Transitive |  |
+| node-releases | MIT | Transitive |  |
+| nofilter | MIT | Transitive |  |
+| nopt | ISC | Transitive |  |
+| normalize-path | MIT | Transitive |  |
+| number-to-bn | MIT | Transitive |  |
+| object-assign | MIT | Transitive |  |
+| object-inspect | MIT | Transitive |  |
+| obliterator | MIT | Transitive |  |
+| obug | MIT | Transitive |  |
+| once | ISC | Transitive |  |
+| optionator | MIT | Transitive |  |
+| ordinal | MIT | Transitive |  |
+| os-tmpdir | MIT | Transitive |  |
+| p-limit | MIT | Transitive |  |
+| p-locate | MIT | Transitive |  |
+| p-map | MIT | Transitive |  |
+| parse-cache-control | BSD | Transitive |  |
+| parse5 | MIT | Transitive |  |
+| path-exists | MIT | Transitive |  |
+| path-is-absolute | MIT | Transitive |  |
+| path-key | MIT | Transitive |  |
+| path-parse | MIT | Transitive |  |
+| path-type | MIT | Transitive |  |
+| pathe | MIT | Transitive |  |
+| pbkdf2 | MIT | Transitive |  |
+| picocolors | ISC | Transitive |  |
+| picomatch | MIT | Transitive |  |
+| pify | MIT | Transitive |  |
+| possible-typed-array-names | MIT | Transitive |  |
+| postcss | MIT | Transitive |  |
+| potpack | ISC | Transitive |  |
+| prelude-ls | MIT | Transitive |  |
+| prettier | MIT | Transitive |  |
+| pretty-format | MIT | Transitive |  |
+| process-nextick-args | MIT | Transitive |  |
+| promise | MIT | Transitive |  |
+| promise-worker-transferable | Apache-2.0 | Transitive |  |
+| prompts | MIT | Transitive |  |
+| proxy-from-env | MIT | Transitive |  |
+| punycode | MIT | Transitive |  |
+| qs | BSD-3-Clause | Transitive |  |
+| queue-microtask | MIT | Transitive |  |
+| randombytes | MIT | Transitive |  |
+| raw-body | MIT | Transitive |  |
+| react | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
+| react-dom | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
+| react-is | MIT | Transitive |  |
+| react-refresh | MIT | Transitive |  |
+| react-use-measure | MIT | Transitive |  |
+| readable-stream | MIT | Transitive |  |
+| readdirp | MIT | Transitive |  |
+| rechoir | MIT | Transitive |  |
+| recursive-readdir | MIT | Transitive |  |
+| reduce-flatten | MIT | Transitive |  |
+| req-cwd | MIT | Transitive |  |
+| req-from | MIT | Transitive |  |
+| require-directory | MIT | Transitive |  |
+| require-from-string | MIT | Transitive |  |
+| resolve | MIT | Transitive |  |
+| resolve-from | MIT | Transitive |  |
+| reusify | MIT | Transitive |  |
+| ripemd160 | MIT | Transitive |  |
+| rlp | MPL-2.0 | Transitive |  |
+| rollup | MIT | Transitive |  |
+| run-parallel | MIT | Transitive |  |
+| safe-buffer | MIT | Transitive |  |
+| safer-buffer | MIT | Transitive |  |
+| saxes | ISC | Transitive |  |
+| sc-istanbul | BSD-3-Clause | Transitive |  |
+| scheduler | MIT | Transitive |  |
+| scrypt-js | MIT | Transitive |  |
+| secp256k1 | MIT | Transitive |  |
+| semver | ISC | Transitive |  |
+| serialize-javascript | BSD-3-Clause | Transitive |  |
+| set-function-length | MIT | Transitive |  |
+| setimmediate | MIT | Transitive |  |
+| setprototypeof | ISC | Transitive |  |
+| sha.js | (MIT AND BSD-3-Clause) | Transitive |  |
+| sha1 | BSD-3-Clause | Transitive |  |
+| sharp | Apache-2.0 | Transitive |  |
+| shebang-command | MIT | Transitive |  |
+| shebang-regex | MIT | Transitive |  |
+| shelljs | BSD-3-Clause | Transitive |  |
+| side-channel | MIT | Transitive |  |
+| side-channel-list | MIT | Transitive |  |
+| side-channel-map | MIT | Transitive |  |
+| side-channel-weakmap | MIT | Transitive |  |
+| siginfo | ISC | Transitive |  |
+| sisteransi | MIT | Transitive |  |
+| slash | MIT | Transitive |  |
+| slice-ansi | MIT | Transitive |  |
+| solc | MIT | Transitive |  |
+| solidity-coverage | ISC | Transitive |  |
+| source-map | BSD-3-Clause | Transitive |  |
+| source-map | BSD | Transitive |  |
+| source-map-js | BSD-3-Clause | Transitive |  |
+| source-map-support | MIT | Transitive |  |
+| split2 | ISC | Transitive |  |
+| sprintf-js | BSD-3-Clause | Transitive |  |
+| stackback | MIT | Transitive |  |
+| stacktrace-parser | MIT | Transitive |  |
+| standardized-audio-context | MIT | Transitive |  |
+| stats-gl | MIT | Transitive |  |
+| stats.js | MIT | Transitive |  |
+| statuses | MIT | Transitive |  |
+| std-env | MIT | Transitive |  |
+| string-format | WTFPL OR MIT | Transitive |  |
+| string-width | MIT | Transitive |  |
+| string_decoder | MIT | Transitive |  |
+| strip-ansi | MIT | Transitive |  |
+| strip-hex-prefix | MIT | Transitive |  |
+| strip-json-comments | MIT | Transitive |  |
+| styled-jsx | MIT | Transitive |  |
+| supports-color | MIT | Transitive |  |
+| supports-preserve-symlinks-flag | MIT | Transitive |  |
+| suspend-react | MIT | Transitive |  |
+| symbol-tree | MIT | Transitive |  |
+| sync-request | MIT | Transitive |  |
+| sync-rpc | MIT | Transitive |  |
+| table | BSD-3-Clause | Transitive |  |
+| table-layout | MIT | Transitive |  |
+| tailwind-merge | MIT | Direct | @Animatica/editor |
+| tailwindcss | MIT | Direct | @Animatica/editor |
+| tapable | MIT | Transitive |  |
+| then-request | MIT | Transitive |  |
+| three | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/web |
+| three-mesh-bvh | MIT | Transitive |  |
+| three-stdlib | MIT | Transitive |  |
+| through2 | MIT | Transitive |  |
+| tinybench | MIT | Transitive |  |
+| tinyexec | MIT | Transitive |  |
+| tinyglobby | MIT | Transitive |  |
+| tinyrainbow | MIT | Transitive |  |
+| tldts | MIT | Transitive |  |
+| tldts-core | MIT | Transitive |  |
+| tmp | MIT | Transitive |  |
+| to-buffer | MIT | Transitive |  |
+| to-regex-range | MIT | Transitive |  |
+| toidentifier | MIT | Transitive |  |
+| tone | MIT | Direct | @Animatica/engine |
+| tough-cookie | BSD-3-Clause | Transitive |  |
+| tr46 | MIT | Transitive |  |
+| troika-three-text | MIT | Transitive |  |
+| troika-three-utils | MIT | Transitive |  |
+| troika-worker-utils | MIT | Transitive |  |
+| ts-command-line-args | ISC | Transitive |  |
+| ts-essentials | MIT | Transitive |  |
+| ts-node | MIT | Transitive |  |
+| tslib | 0BSD | Transitive |  |
+| tsort | MIT | Transitive |  |
+| tunnel-rat | MIT | Transitive |  |
+| turbo | MIT | Direct | Animatica |
+| turbo-linux-64 | MIT | Transitive |  |
+| type-check | MIT | Transitive |  |
+| type-detect | MIT | Transitive |  |
+| type-fest | (MIT OR CC0-1.0) | Transitive |  |
+| typechain | MIT | Transitive |  |
+| typed-array-buffer | MIT | Transitive |  |
+| typedarray | MIT | Transitive |  |
+| typescript | Apache-2.0 | Direct | @Animatica/contracts, @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web, Animatica |
+| typical | MIT | Transitive |  |
+| uglify-js | BSD-2-Clause | Transitive |  |
+| undici | MIT | Transitive |  |
+| undici-types | MIT | Transitive |  |
+| universalify | MIT | Transitive |  |
+| unpipe | MIT | Transitive |  |
+| update-browserslist-db | MIT | Transitive |  |
+| use-sync-external-store | MIT | Transitive |  |
+| utf8 | MIT | Transitive |  |
+| util-deprecate | MIT | Transitive |  |
+| utility-types | MIT | Transitive |  |
+| uuid | MIT | Direct | @Animatica/engine |
+| v8-compile-cache-lib | MIT | Transitive |  |
+| vite | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/platform |
+| vitest | MIT | Direct | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
+| w3c-xmlserializer | MIT | Transitive |  |
+| web3-utils | LGPL-3.0 | Transitive |  |
+| webgl-constants | MIT | Transitive |  |
+| webgl-sdf-generator | MIT | Transitive |  |
+| webidl-conversions | BSD-2-Clause | Transitive |  |
+| whatwg-mimetype | MIT | Transitive |  |
+| whatwg-url | MIT | Transitive |  |
+| which | ISC | Transitive |  |
+| which-typed-array | MIT | Transitive |  |
+| why-is-node-running | MIT | Transitive |  |
+| widest-line | MIT | Transitive |  |
+| word-wrap | MIT | Transitive |  |
+| wordwrap | MIT | Transitive |  |
+| wordwrapjs | MIT | Transitive |  |
+| workerpool | Apache-2.0 | Transitive |  |
+| wrap-ansi | MIT | Transitive |  |
+| wrappy | ISC | Transitive |  |
+| ws | MIT | Transitive |  |
+| xml-name-validator | Apache-2.0 | Transitive |  |
+| xmlchars | MIT | Transitive |  |
+| y18n | ISC | Transitive |  |
+| yallist | ISC | Transitive |  |
+| yargs | MIT | Transitive |  |
+| yargs-parser | ISC | Transitive |  |
+| yargs-unparser | MIT | Transitive |  |
+| yn | MIT | Transitive |  |
+| yocto-queue | MIT | Transitive |  |
+| zod | MIT | Direct | @Animatica/engine, @Animatica/web |
+| zundo | MIT | Direct | @Animatica/engine |
+| zustand | MIT | Direct | @Animatica/engine |

--- a/scripts/generate_license_audit.py
+++ b/scripts/generate_license_audit.py
@@ -1,0 +1,107 @@
+import json
+import os
+import glob
+
+def get_package_jsons():
+    return glob.glob("**/package.json", recursive=True)
+
+def parse_package_jsons():
+    dep_map = {}
+    workspace_packages = set()
+
+    for path in get_package_jsons():
+        if "node_modules" in path:
+            continue
+        with open(path, 'r') as f:
+            data = json.load(f)
+            pkg_name = data.get("name")
+            if not pkg_name:
+                continue
+            workspace_packages.add(pkg_name)
+
+            for dep_type in ["dependencies", "devDependencies", "peerDependencies"]:
+                deps = data.get(dep_type, {})
+                for dep, version in deps.items():
+                    if dep not in dep_map:
+                        dep_map[dep] = []
+                    dep_map[dep].append(pkg_name)
+
+    return dep_map, workspace_packages
+
+def generate_report():
+    dep_map, workspace_packages = parse_package_jsons()
+
+    with open("licenses.json", 'r') as f:
+        licenses_data = json.load(f)
+
+    all_deps = []
+    license_counts = {}
+    non_mit = []
+
+    # Process all dependencies from pnpm licenses list
+    for license_name, deps in licenses_data.items():
+        license_counts[license_name] = len(deps)
+        for dep in deps:
+            name = dep["name"]
+            is_direct = name in dep_map
+            used_in = ", ".join(sorted(set(dep_map.get(name, []))))
+
+            # Internal workspace packages might not be in licenses.json if pnpm excludes them
+            # or they might be listed as Unknown.
+            # But they should be MIT.
+
+            dep_info = {
+                "name": name,
+                "license": license_name,
+                "type": "Direct" if is_direct else "Transitive",
+                "used_in": used_in if is_direct else ""
+            }
+            all_deps.append(dep_info)
+
+            if license_name != "MIT":
+                non_mit.append(dep_info)
+
+    # Handle workspace packages that might be missing from licenses.json
+    for pkg in workspace_packages:
+        if not any(d["name"] == pkg for d in all_deps):
+            dep_info = {
+                "name": pkg,
+                "license": "MIT",
+                "type": "Workspace",
+                "used_in": "Internal"
+            }
+            all_deps.append(dep_info)
+            license_counts["MIT"] = license_counts.get("MIT", 0) + 1
+
+    all_deps.sort(key=lambda x: x["name"].lower())
+    non_mit.sort(key=lambda x: x["name"].lower())
+
+    with open("docs/LICENSE_AUDIT.md", 'w') as f:
+        f.write("# License Audit Report\n\n")
+        f.write(f"Date: 2026-03-24\n\n")
+
+        f.write("## Summary\n\n")
+        f.write("| License | Count |\n")
+        f.write("| --- | --- |\n")
+        for lic, count in sorted(license_counts.items(), key=lambda x: x[1], reverse=True):
+            f.write(f"| {lic} | {count} |\n")
+        f.write("\n")
+
+        f.write("## 🚩 Non-MIT Licenses\n\n")
+        if not non_mit:
+            f.write("No non-MIT licenses found.\n")
+        else:
+            f.write("| Dependency | License | Type | Used In |\n")
+            f.write("| --- | --- | --- | --- |\n")
+            for dep in non_mit:
+                f.write(f"| {dep['name']} | {dep['license']} | {dep['type']} | {dep['used_in']} |\n")
+        f.write("\n")
+
+        f.write("## All Dependencies\n\n")
+        f.write("| Dependency | License | Type | Used In |\n")
+        f.write("| --- | --- | --- | --- |\n")
+        for dep in all_deps:
+            f.write(f"| {dep['name']} | {dep['license']} | {dep['type']} | {dep['used_in']} |\n")
+
+if __name__ == "__main__":
+    generate_report()


### PR DESCRIPTION
This PR implements a comprehensive license audit of all project dependencies as requested by the License Auditor.

Key Changes:
- **`docs/LICENSE_AUDIT.md`**: A detailed report containing:
    - Summary of license counts.
    - Flagged non-MIT licenses (Transitive and Direct).
    - A full table of all dependencies with their License, Type (Direct/Transitive/Workspace), and 'Used In' information for direct dependencies.
- **`scripts/generate_license_audit.py`**: A Python script to automate the generation of the audit report by parsing `package.json` files and merging with `pnpm licenses` data.

Verification:
- The report was generated after running `pnpm install` and `pnpm licenses list --json`.
- All workspace packages (@Animatica/*) are correctly identified and marked as MIT/Internal.
- Non-MIT licenses (Apache, BSD, ISC, etc.) are clearly flagged in a dedicated section.

Note: Temporary files and unintended performance baseline changes from `pnpm test` were cleaned up before submission.

---
*PR created automatically by Jules for task [11272302126068857031](https://jules.google.com/task/11272302126068857031) started by @Fredess74*