### PR TITLE
chore(bundle): size audit 2026-03-25

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-03-25
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 110K | +8K | First Load JS for / (Next.js 15) |
+| **@Animatica/engine** | 135.4K | +64.4K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 3,489.0K | +3,413.0K | Significant growth due to UI components and 600+ modules |
+| **@Animatica/platform** | 0.18K | -0.02K | Minimal exports |
+| **@Animatica/contracts** | 0K | -8K | No build output artifacts found |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3,624.58K** (excluding web), **3,734.58K** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3,489.0K)
+- `dist/index.js`: 2,181.2K
+- `dist/index.cjs`: 1,307.8K
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-03-25.
+- `@Animatica/editor` has ballooned to 3.4M following the integration of the full UI component suite and layout system.
+- `@Animatica/engine` nearly doubled in size as more renderers and animation logic were added.
+- `@Animatica/web` remains relatively stable at 110K First Load JS.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Investigate code-splitting or lazy loading for the UI library to reduce the initial bundle size. 3.4MB is very high for a library.
+- **@Animatica/engine**: Continue to monitor size as Task 11-14 (Characters) are fully integrated.
+- **@Animatica/web**: Monitor the impact of importing `@Animatica/editor` on the final application bundle.


### PR DESCRIPTION
Performed a comprehensive bundle size audit of the Animatica monorepo.

Key findings:
- @Animatica/editor has grown significantly to ~3.5MB due to the integration of UI components.
- @Animatica/engine has nearly doubled to ~135KB.
- @Animatica/web remains stable at ~110KB (First Load JS).
- @Animatica/platform is minimal at ~0.18KB.

Updated docs/BUNDLE_REPORT.md with the latest metrics and added suggestions for optimization.

---
*PR created automatically by Jules for task [13645123270192638387](https://jules.google.com/task/13645123270192638387) started by @Fredess74*