### PR TITLE
chore(bundle): size audit

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-03-26
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 110K | +8K | First Load JS (built successfully) |
+| **@Animatica/engine** | 135.4K | +64.4K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 3.5M | +3.4M | Includes index.js (2.2M) and index.cjs (1.3M) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
+| **@Animatica/contracts** | 0K | -8K | No compiled contracts |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.6M** (excluding web), **3.7M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.5M)
+- `dist/index.js`: 2.2M
+- `dist/index.cjs`: 1.3M
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-03-26.
+- Massive growth in `@Animatica/editor` due to UI component library and R3F dependencies.
+- `@Animatica/engine` size increased as more core animation features were added.
+- `@Animatica/web` remains stable around 110K First Load JS.
 
 ## Suggestions
+- **@Animatica/editor**: Extremely large bundle size (3.5M). Recommend investigating tree-shaking or dynamic imports for heavy 3D assets and UI components.
 - **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/web**: 110K First Load JS is good, but keep watching as more editor features are integrated into the main application.


### PR DESCRIPTION
Updated docs/BUNDLE_REPORT.md with the latest bundle sizes from the 2026-03-26 build output. Calculated new totals and updated comparison data, highlighting the growth in @Animatica/editor and @Animatica/engine.

---
*PR created automatically by Jules for task [1508325264441971523](https://jules.google.com/task/1508325264441971523) started by @Fredess74*