### PR TITLE
Add engine performance benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
-import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
+import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3, AnimationTrack, ProjectMeta, Environment, Timeline, PlaybackState } from '../types';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -34,7 +34,7 @@ describe('Engine Benchmarks', () => {
     });
 
     describe('Interpolation Performance', () => {
-        it('Number Interpolation (10k ops, 10k keyframes)', () => {
+        it('Number Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<number>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -44,15 +44,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Number Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Number Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
-        });
+        }, 10000);
 
-        it('Vector3 Interpolation (10k ops, 10k keyframes)', () => {
+        it('Vector3 Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<Vector3>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -62,15 +62,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Vector3 Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Vector3 Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
-        });
+        }, 15000);
 
-        it('Color Interpolation (10k ops, 10k keyframes)', () => {
+        it('Color Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<string>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -80,19 +80,45 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Color Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Color Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
+                }
+            });
+        }, 15000);
+
+        it('evaluateTracksAtTime (1k ops, 100 tracks x 10 keyframes)', () => {
+            const tracks: AnimationTrack[] = [];
+            for (let i = 0; i < 100; i++) {
+                const keyframes: Keyframe<number>[] = [];
+                for (let j = 0; j < 10; j++) {
+                    keyframes.push({
+                        time: j,
+                        value: j * 10,
+                        easing: 'linear',
+                    });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'transform.position.x',
+                    keyframes,
+                });
+            }
+
+            measure('evaluateTracksAtTime (1k ops)', () => {
+                for (let i = 0; i < 1000; i++) {
+                    const t = Math.random() * 10;
+                    evaluateTracksAtTime(tracks, t);
                 }
             });
         });
     });
 
     describe('Schema Validation Performance', () => {
-        it('Project Schema Validation (100 runs, 100 actors)', () => {
+        it('Project Schema Validation (100 runs, 150 actors)', () => {
             const actors: Actor[] = [];
-            for (let i = 0; i < 100; i++) {
+            for (let i = 0; i < 150; i++) {
                 const actor: PrimitiveActor = {
                     id: `actor-${i}`,
                     name: `Actor ${i}`,
@@ -144,20 +170,25 @@ describe('Engine Benchmarks', () => {
     });
 
     describe('Store Performance', () => {
-        it('Store Update Throughput (10k playback updates)', () => {
+        it('Store Playback Updates (10k playback updates)', () => {
             const { setState, getState } = useSceneStore;
 
+            const initialMeta: ProjectMeta = { title: 'Reset', version: '1.0.0' };
+            const initialEnv: Environment = {
+                ambientLight: { intensity: 0.5, color: '#ffffff' },
+                sun: { position: [10, 10, 10], intensity: 1, color: '#ffffff' },
+                skyColor: '#87CEEB',
+            };
+            const initialTimeline: Timeline = { duration: 10, cameraTrack: [], animationTracks: [], markers: [] };
+            const initialPlayback: PlaybackState = { currentTime: 0, isPlaying: false, frameRate: 24, speed: 1.0, direction: 1, loopMode: 'none' };
+
             setState({
-                meta: { title: 'Reset', version: '1.0.0' },
-                environment: {
-                    ambientLight: { intensity: 0.5, color: '#ffffff' },
-                    sun: { position: [10, 10, 10], intensity: 1, color: '#ffffff' },
-                    skyColor: '#87CEEB',
-                },
+                meta: initialMeta,
+                environment: initialEnv,
                 actors: [],
-                timeline: { duration: 10, cameraTrack: [], animationTracks: [], markers: [] },
+                timeline: initialTimeline,
                 library: { clips: [] },
-                playback: { currentTime: 0, isPlaying: false, frameRate: 24, speed: 1.0, direction: 1, loopMode: 'none' },
+                playback: initialPlayback,
             });
 
             measure('Store Playback Updates (10k ops)', () => {
@@ -167,24 +198,42 @@ describe('Engine Benchmarks', () => {
             });
         });
 
-        it('Store Actor CRUD Throughput (1k actors)', () => {
+        it('Store Actor CRUD Throughput (1k actors)', { timeout: 30000 }, () => {
             const { setState, getState } = useSceneStore;
 
+            const initialMeta: ProjectMeta = { title: 'CRUD', version: '1.0.0' };
+            const initialEnv: Environment = {
+                ambientLight: { intensity: 0.5, color: '#ffffff' },
+                sun: { position: [10, 10, 10], intensity: 1, color: '#ffffff' },
+                skyColor: '#87CEEB',
+            };
+            const initialTimeline: Timeline = { duration: 10, cameraTrack: [], animationTracks: [], markers: [] };
+            const initialPlayback: PlaybackState = { currentTime: 0, isPlaying: false, frameRate: 24, speed: 1.0, direction: 1, loopMode: 'none' };
+
             setState({
+                meta: initialMeta,
+                environment: initialEnv,
                 actors: [],
-                playback: { currentTime: 0, isPlaying: false, frameRate: 24, speed: 1.0, direction: 1, loopMode: 'none' },
-            } as any);
+                timeline: initialTimeline,
+                library: { clips: [] },
+                playback: initialPlayback,
+            });
+
+            const prePopulatedActors: PrimitiveActor[] = [];
+            for (let i = 0; i < 1000; i++) {
+                prePopulatedActors.push({
+                    id: `bench-${i}`,
+                    name: `Actor ${i}`,
+                    type: 'primitive',
+                    transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] },
+                    visible: true,
+                    properties: { shape: 'box', color: '#ff0000', roughness: 0.5, metalness: 0.5, opacity: 1, wireframe: false }
+                });
+            }
 
             measure('Store Add Actor (1k ops)', () => {
-                for (let i = 0; i < 1000; i++) {
-                    getState().addActor({
-                        id: `bench-${i}`,
-                        name: `Actor ${i}`,
-                        type: 'primitive',
-                        transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] },
-                        visible: true,
-                        properties: { shape: 'box', color: '#ff0000', roughness: 0.5, metalness: 0.5, opacity: 1, wireframe: false }
-                    } as PrimitiveActor);
+                for (const actor of prePopulatedActors) {
+                    getState().addActor(actor);
                 }
             });
 

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,11 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (100k ops)": "5607.42ms",
+  "Vector3 Interpolation (100k ops)": "4679.41ms",
+  "Color Interpolation (100k ops)": "4539.59ms",
+  "evaluateTracksAtTime (1k ops)": "32.73ms",
+  "Schema Validation Speed (100 runs)": "78.75ms",
+  "Store Playback Updates (10k ops)": "212.19ms",
+  "Store Add Actor (1k ops)": "150.89ms",
+  "Store Update Actor (1k ops)": "1304.05ms",
+  "Store Remove Actor (1k ops)": "1007.90ms"
 }


### PR DESCRIPTION
I have implemented a comprehensive set of performance benchmarks for the `@Animatica/engine` package in `packages/engine/src/__tests__/benchmark.test.ts`. 

Key improvements and additions:
- **Interpolation Benchmarks:** Increased iterations to 100,000 for Number, Vector3, and Color interpolation to provide more stable and significant metrics.
- **Track Evaluation:** Added a new benchmark for `evaluateTracksAtTime` simulating 100 tracks with 10 keyframes each.
- **Schema Validation:** Updated the Zod schema validation benchmark to use 150 actors, providing a realistic stress test for project state parsing.
- **Store Performance:** Benchmarked store playback updates (10k ops) and actor CRUD operations (1k actors). CRUD tests now use pre-populated actor pools for more accurate measurement.
- **Code Quality:** Refactored the benchmark file to remove all `any` type casts, ensuring compliance with the project's strict TypeScript rules defined in `JULES_GUIDE.md`.
- **Stability:** Added explicit timeouts (up to 30s) for longer-running benchmarks to prevent flaky CI failures.
- **Reporting:** All results are automatically recorded to `reports/baseline_metrics.json` upon test completion.

I verified the changes by running `pnpm --filter @Animatica/engine test src/__tests__/benchmark.test.ts --run`, and all benchmarks passed successfully, generating a valid metrics report.

---
*PR created automatically by Jules for task [2006419051918076558](https://jules.google.com/task/2006419051918076558) started by @Fredess74*