### PR TITLE
Implement BoneController for character posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+  let headBone: THREE.Bone
+  let spineBone: THREE.Bone
+
+  beforeEach(() => {
+    bones = new Map()
+    headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    spineBone = new THREE.Bone()
+    spineBone.name = 'Spine'
+
+    bones.set('Head', headBone)
+    bones.set('Spine', spineBone)
+
+    controller = new BoneController(bones)
+  })
+
+  it('applies rotation to bones immediately when smoothing is 1', () => {
+    controller.setSmoothing(1)
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+
+    controller.update(pose, 1 / 60)
+
+    // With smoothing 1, it should reach target in one frame
+    // [PI/2, 0, 0] as Euler -> Quaternion
+    const expected = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0))
+
+    expect(headBone.quaternion.x).toBeCloseTo(expected.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expected.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expected.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expected.w)
+  })
+
+  it('interpolates rotation when smoothing is less than 1', () => {
+    controller.setSmoothing(0.5)
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+
+    // First update
+    controller.update(pose, 1 / 60)
+
+    // With smoothing 0.5 and delta 1/60, alpha = 1 - (1-0.5)^1 = 0.5
+    // It should be halfway to the target
+    const target = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0))
+    const initial = new THREE.Quaternion(0, 0, 0, 1)
+    const expected = initial.clone().slerp(target, 0.5)
+
+    expect(headBone.quaternion.x).toBeCloseTo(expected.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expected.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expected.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expected.w)
+  })
+
+  it('is frame-rate independent', () => {
+    controller.setSmoothing(0.15)
+    const pose: BodyPose = {
+      head: [1, 0, 0],
+    }
+
+    // Case 1: One large step (1/30s)
+    const headBone1 = new THREE.Bone()
+    const controller1 = new BoneController(new Map([['Head', headBone1]]))
+    controller1.setSmoothing(0.15)
+    controller1.update(pose, 1 / 30)
+
+    // Case 2: Two small steps (1/60s each)
+    const headBone2 = new THREE.Bone()
+    const controller2 = new BoneController(new Map([['Head', headBone2]]))
+    controller2.setSmoothing(0.15)
+    controller2.update(pose, 1 / 60)
+    controller2.update(pose, 1 / 60)
+
+    // Both should result in the same rotation
+    expect(headBone1.quaternion.x).toBeCloseTo(headBone2.quaternion.x)
+    expect(headBone1.quaternion.y).toBeCloseTo(headBone2.quaternion.y)
+    expect(headBone1.quaternion.z).toBeCloseTo(headBone2.quaternion.z)
+    expect(headBone1.quaternion.w).toBeCloseTo(headBone2.quaternion.w)
+  })
+
+  it('handles missing bones gracefully', () => {
+    const pose: BodyPose = {
+      leftArm: [1, 1, 1], // LeftArm bone is not in our map
+    }
+
+    expect(() => controller.update(pose, 0.016)).not.toThrow()
+  })
+
+  it('resets bones to identity rotation', () => {
+    headBone.quaternion.set(1, 0, 0, 1).normalize()
+    spineBone.quaternion.set(0, 1, 0, 1).normalize()
+
+    controller.reset()
+
+    expect(headBone.quaternion.x).toBe(0)
+    expect(headBone.quaternion.y).toBe(0)
+    expect(headBone.quaternion.z).toBe(0)
+    expect(headBone.quaternion.w).toBe(1)
+
+    expect(spineBone.quaternion.x).toBe(0)
+    expect(spineBone.quaternion.y).toBe(0)
+    expect(spineBone.quaternion.z).toBe(0)
+    expect(spineBone.quaternion.w).toBe(1)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,85 @@
+import * as THREE from 'three'
+import { BodyPose, Vector3 } from '../types'
+
+/**
+ * BoneController — Maps BodyPose properties to Three.js bones and handles smooth interpolation.
+ * Uses static scratch variables for performance to avoid GC pressure in the update loop.
+ */
+export class BoneController {
+  private static readonly SCRATCH_EULER = new THREE.Euler()
+  private static readonly SCRATCH_QUATERNION = new THREE.Quaternion()
+  private static readonly TARGET_QUATERNION = new THREE.Quaternion()
+
+  private bones: Map<string, THREE.Bone>
+  private smoothing: number = 0.15 // Default smoothing factor
+
+  /**
+   * @param bones Map of bone names to THREE.Bone instances.
+   */
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Sets the smoothing factor for bone rotations.
+   * @param value Smoothing factor (0-1), where 1 is immediate.
+   */
+  setSmoothing(value: number): void {
+    this.smoothing = Math.max(0, Math.min(1, value))
+  }
+
+  /**
+   * Updates bone rotations based on the provided BodyPose.
+   * This should be called every frame after the animation mixer update.
+   *
+   * @param pose The target body pose.
+   * @param delta Frame delta time in seconds.
+   */
+  update(pose: BodyPose, delta: number): void {
+    if (!pose) return
+
+    // Smoothing formula: 1 - (1 - alpha)^(delta * 60)
+    // This makes the smoothing frame-rate independent.
+    const alpha = 1 - Math.pow(1 - this.smoothing, delta * 60)
+
+    this.applyBoneRotation('Head', pose.head, alpha)
+    this.applyBoneRotation('Spine', pose.spine, alpha)
+    this.applyBoneRotation('LeftArm', pose.leftArm, alpha)
+    this.applyBoneRotation('RightArm', pose.rightArm, alpha)
+    this.applyBoneRotation('LeftUpperLeg', pose.leftLeg, alpha)
+    this.applyBoneRotation('RightUpperLeg', pose.rightLeg, alpha)
+  }
+
+  /**
+   * Applies rotation to a specific bone with lerping.
+   */
+  private applyBoneRotation(boneName: string, rotation: Vector3 | undefined, alpha: number): void {
+    if (!rotation) return
+
+    const bone = this.bones.get(boneName)
+    if (!bone) return
+
+    // Convert Euler [x, y, z] to Quaternion
+    BoneController.SCRATCH_EULER.set(rotation[0], rotation[1], rotation[2])
+    BoneController.TARGET_QUATERNION.setFromEuler(BoneController.SCRATCH_EULER)
+
+    // Smoothly interpolate current bone rotation towards target
+    // We use slerp for quaternions to ensure smooth transitions
+    bone.quaternion.slerp(BoneController.TARGET_QUATERNION, alpha)
+  }
+
+  /**
+   * Resets all controlled bones to their default (zero) rotation.
+   */
+  reset(): void {
+    const controlledBones = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+    BoneController.TARGET_QUATERNION.set(0, 0, 0, 1)
+
+    controlledBones.forEach((name) => {
+      const bone = this.bones.get(name)
+      if (bone) {
+        bone.quaternion.copy(BoneController.TARGET_QUATERNION)
+      }
+    })
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -14,6 +14,8 @@ export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 export { EyeController } from './EyeController'
 export type { EyeState } from './EyeController'
 
+export { BoneController } from './BoneController'
+
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
+import * as THREE from 'three'
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,13 +9,16 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: (val: any) => ({ current: val }),
+    useMemo: (factory: any) => factory(),
+    useEffect: () => {},
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: () => {},
+  useThree: () => ({}),
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +42,10 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
+  it('renders a group with correct transform', () => {
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const Component = CharacterRenderer.type || CharacterRenderer;
+    const result = Component({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +58,21 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
+    // First child should be the rig (primitive object={rig.root})
+    const rigPrimitive = children.find(child => child.type === 'primitive')
+    expect(rigPrimitive).toBeDefined()
 
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    const rigObject = (rigPrimitive?.props as any)?.object
+    expect(rigObject).toBeInstanceOf(THREE.Group)
   })
 
-  it('renders nothing when visible is false', () => {
+  it('renders a group with visible set to false when actor is invisible', () => {
     const invisibleActor = { ...mockActor, visible: false }
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
-  })
+    const Component = CharacterRenderer.type || CharacterRenderer;
+    const result = Component({ actor: invisibleActor }) as React.ReactElement
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    expect(result).not.toBeNull()
+    expect(result.props.visible).toBe(false)
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -71,6 +73,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Setup eye controller
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
+
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
 
     return () => {
       animator.dispose()
@@ -108,6 +114,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Face morph blending
     if (faceMorphRef.current) {
       faceMorphRef.current.update(delta)
+    }
+
+    // Bone pose overrides (applied after animation)
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.update(actor.bodyPose, delta)
     }
 
     // Eye auto-blink + look-at

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "462.89ms",
+  "Vector3 Interpolation (10k ops)": "542.99ms",
+  "Color Interpolation (10k ops)": "493.13ms",
+  "Schema Validation Speed (100 runs)": "82.87ms",
+  "Store Playback Updates (10k ops)": "240.50ms",
+  "Store Add Actor (1k ops)": "145.06ms",
+  "Store Update Actor (1k ops)": "1275.53ms",
+  "Store Remove Actor (1k ops)": "1020.17ms"
 }


### PR DESCRIPTION
Implemented the BoneController class in @Animatica/engine to map BodyPose properties to Three.js bones with smooth, frame-rate independent interpolation. Integrated the controller into CharacterRenderer.tsx to allow for procedural pose overrides on top of skeletal animations. Added comprehensive unit tests for the controller and fixed regressions in character renderer tests.

---
*PR created automatically by Jules for task [11197969686365634587](https://jules.google.com/task/11197969686365634587) started by @Fredess74*