### PR TITLE
feat(engine): implement BoneController for character body posing (#12)

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { HUMANOID_BONES } from './CharacterLoader'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    // Create bones from the official HUMANOID_BONES list
+    HUMANOID_BONES.forEach((name) => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+    controller = new BoneController(bones)
+  })
+
+  it('should apply rotations to bones correctly', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      spine: [0.4, 0.5, 0.6],
+    }
+
+    controller.update(pose)
+
+    const headBone = bones.get('Head')!
+    const spineBone = bones.get('Spine')!
+
+    const expectedHeadEuler = new THREE.Euler(0.1, 0.2, 0.3)
+    const expectedHeadQuaternion = new THREE.Quaternion().setFromEuler(expectedHeadEuler)
+
+    const expectedSpineEuler = new THREE.Euler(0.4, 0.5, 0.6)
+    const expectedSpineQuaternion = new THREE.Quaternion().setFromEuler(expectedSpineEuler)
+
+    expect(headBone.quaternion.x).toBeCloseTo(expectedHeadQuaternion.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expectedHeadQuaternion.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expectedHeadQuaternion.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expectedHeadQuaternion.w)
+
+    expect(spineBone.quaternion.x).toBeCloseTo(expectedSpineQuaternion.x)
+    expect(spineBone.quaternion.y).toBeCloseTo(expectedSpineQuaternion.y)
+    expect(spineBone.quaternion.z).toBeCloseTo(expectedSpineQuaternion.z)
+    expect(spineBone.quaternion.w).toBeCloseTo(expectedSpineQuaternion.w)
+  })
+
+  it('should handle missing bones gracefully', () => {
+    const incompleteBones = new Map<string, THREE.Bone>()
+    const headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    incompleteBones.set('Head', headBone)
+
+    const controllerWithMissingBones = new BoneController(incompleteBones)
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      spine: [0.4, 0.5, 0.6], // Spine is missing in this rig
+    }
+
+    // Should not throw
+    expect(() => controllerWithMissingBones.update(pose)).not.toThrow()
+
+    const expectedHeadEuler = new THREE.Euler(0.1, 0.2, 0.3)
+    const expectedHeadQuaternion = new THREE.Quaternion().setFromEuler(expectedHeadEuler)
+
+    expect(headBone.quaternion.x).toBeCloseTo(expectedHeadQuaternion.x)
+  })
+
+  it('should handle undefined pose properties', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+    }
+    // spine, arms, legs are undefined
+
+    controller.update(pose)
+
+    const headBone = bones.get('Head')!
+    const spineBone = bones.get('Spine')!
+
+    expect(headBone.quaternion.x).not.toBe(0)
+    expect(spineBone.quaternion.x).toBe(0) // Should remain at identity
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,52 @@
+import * as THREE from 'three'
+import type { BodyPose } from '../types'
+
+/**
+ * BoneController — Manages bone-level rotations for character body posing.
+ * Allows overriding or layering custom poses on top of skeletal animation.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private scratchEuler: THREE.Euler = new THREE.Euler()
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Update bone rotations based on the provided BodyPose.
+   * This should be called after the animation mixer update to allow pose overrides.
+   * @param pose The body pose object containing Euler rotations (radians).
+   */
+  update(pose: BodyPose): void {
+    if (pose.head) {
+      this.applyRotation('Head', pose.head)
+    }
+    if (pose.spine) {
+      this.applyRotation('Spine', pose.spine)
+    }
+    if (pose.leftArm) {
+      this.applyRotation('LeftArm', pose.leftArm)
+    }
+    if (pose.rightArm) {
+      this.applyRotation('RightArm', pose.rightArm)
+    }
+    if (pose.leftLeg) {
+      this.applyRotation('LeftUpperLeg', pose.leftLeg)
+    }
+    if (pose.rightLeg) {
+      this.applyRotation('RightUpperLeg', pose.rightLeg)
+    }
+  }
+
+  /**
+   * Internal helper to apply Euler rotation to a specific bone.
+   */
+  private applyRotation(boneName: string, rotation: [number, number, number]): void {
+    const bone = this.bones.get(boneName)
+    if (bone) {
+      this.scratchEuler.set(rotation[0], rotation[1], rotation[2])
+      bone.quaternion.setFromEuler(this.scratchEuler)
+    }
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -6,6 +6,7 @@ export { extractRig, createProceduralHumanoid, HUMANOID_BONES } from './Characte
 export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
+export { BoneController } from './BoneController'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 
 export { FaceMorphController, BLEND_SHAPES, EXPRESSION_PRESETS, VISEME_MAP } from './FaceMorphController'

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,13 +8,16 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: (val: any) => ({ current: val }),
+    useMemo: (factory: any) => factory(),
+    useEffect: () => {},
+    memo: (comp: any) => comp,
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock R3F useFrame
+vi.mock('@react-three/fiber', () => ({
+  useFrame: () => {},
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +41,8 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing primitive with correct transform', () => {
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +55,45 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Check for primitive object (rig.root)
+    const primitive = children.find((child) => child.type === 'primitive')
+    expect(primitive).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection indicator when selected', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Selection ring should be present
+    const selectionRing = children.find((child) => child.type === 'mesh' && (child.props as any).position?.[1] === 0.01)
+    expect(selectionRing).toBeDefined()
+  })
+
+  it('renders eyes in the rig root', () => {
+    // This indirectly tests if the rig is built correctly and rendered
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
+    const props = result.props as any
+    const children = React.Children.toArray(props.children) as React.ReactElement[]
+
+    const primitive = children.find((child) => child.type === 'primitive') as any
+    const rigRoot = primitive.props.object as THREE.Group
+
+    let eyesFound = 0
+    rigRoot.traverse((child) => {
+      if (child.name === 'Head') {
+        const eyes = child.children.filter(c => c.type === 'Mesh' && c.geometry.type === 'SphereGeometry')
+        eyesFound = eyes.length
+      }
+    })
+
+    // Procedural humanoid has 2 eyes
+    expect(eyesFound).toBeGreaterThanOrEqual(2)
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -71,6 +73,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Setup eye controller
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
+
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
 
     return () => {
       animator.dispose()
@@ -110,6 +116,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       faceMorphRef.current.update(delta)
     }
 
+    // Apply custom body pose overrides
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.update(actor.bodyPose)
+    }
+
     // Eye auto-blink + look-at
     if (eyeControllerRef.current && faceMorphRef.current) {
       const headPos = groupRef.current
@@ -120,6 +131,9 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       faceMorphRef.current.setImmediate(eyeValues)
     }
   })
+
+  // Rules of Hooks: conditional return must be after all hooks
+  if (!actor.visible) return null
 
   return (
     <group


### PR DESCRIPTION
This PR implements Task 12: Bone Controller. 

It introduces a new `BoneController` class in `@Animatica/engine` that allows overriding character skeletal animation with manual body poses. The controller is integrated into the `CharacterRenderer` R3F component, ensuring that poses defined in the `BodyPose` data (e.g., head, spine, limbs) are applied every frame after the animation mixer.

Performance optimizations were included to reuse a scratch `Euler` object in the render loop. The `CharacterRenderer` was also refactored to ensure all hooks are called before any conditional returns, adhering to the Rules of Hooks.

New tests verify the mapping from `BodyPose` to Three.js bones and handle edge cases like missing bones in a rig.

---
*PR created automatically by Jules for task [12072491199091433608](https://jules.google.com/task/12072491199091433608) started by @Fredess74*