### PR TITLE
refactor(store): optimize state

### DIFF
--- a/packages/engine/src/store/sceneStore.test.ts
+++ b/packages/engine/src/store/sceneStore.test.ts
@@ -6,6 +6,7 @@ describe('sceneStore', () => {
   beforeEach(() => {
     useSceneStore.setState({
       actors: [],
+      actorsById: {},
       selectedActorId: null,
       timeline: { duration: 10, cameraTrack: [], animationTracks: [], markers: [] },
       environment: {
@@ -36,6 +37,7 @@ describe('sceneStore', () => {
     useSceneStore.getState().addActor(actor);
     expect(useSceneStore.getState().actors).toHaveLength(1);
     expect(useSceneStore.getState().actors[0]).toEqual(actor);
+    expect(useSceneStore.getState().actorsById['1']).toEqual(actor);
   });
 
   it('should remove an actor', () => {
@@ -43,6 +45,7 @@ describe('sceneStore', () => {
     useSceneStore.getState().addActor(actor);
     useSceneStore.getState().removeActor('1');
     expect(useSceneStore.getState().actors).toHaveLength(0);
+    expect(useSceneStore.getState().actorsById['1']).toBeUndefined();
   });
 
   it('should update an actor', () => {
@@ -50,6 +53,7 @@ describe('sceneStore', () => {
     useSceneStore.getState().addActor(actor);
     useSceneStore.getState().updateActor('1', { name: 'Updated Actor' });
     expect(useSceneStore.getState().actors[0].name).toBe('Updated Actor');
+    expect(useSceneStore.getState().actorsById['1'].name).toBe('Updated Actor');
   });
 
   it('should set environment', () => {

--- a/packages/engine/src/store/sceneStore.ts
+++ b/packages/engine/src/store/sceneStore.ts
@@ -32,8 +32,17 @@ export const useSceneStore = create<SceneStoreState>()(
         // Only persist project state, not playback or selection
         partialize: (state) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { playback, selectedActorId, ...rest } = state;
+          const { playback, selectedActorId, actorsById, ...rest } = state;
           return rest as unknown as SceneStoreState;
+        },
+        // Rebuild actorsById lookup on hydration
+        onRehydrateStorage: () => (state) => {
+          if (state && state.actors) {
+            state.actorsById = state.actors.reduce((acc, actor) => {
+              acc[actor.id] = actor;
+              return acc;
+            }, {} as Record<string, Actor>);
+          }
         },
       }
     ),
@@ -71,9 +80,10 @@ export type { SceneStoreState, PlaybackState, LoopMode } from './types';
 
 /**
  * Selector to get an actor by its ID.
+ * Optimized with O(1) lookup using actorsById.
  */
 export const getActorById = (id: string) => (state: SceneStoreState): Actor | undefined =>
-  state.actors.find((a) => a.id === id);
+  state.actorsById[id];
 
 /**
  * Selector to get all currently visible actors.
@@ -91,9 +101,10 @@ export const getCurrentTime = (state: SceneStoreState): number =>
 
 /**
  * Hook to select a specific actor by ID.
+ * Optimized with O(1) lookup using actorsById.
  */
 export const useActorById = (id: string) =>
-  useSceneStore((state) => state.actors.find((a) => a.id === id));
+  useSceneStore((state) => state.actorsById[id]);
 
 /**
  * Hook to get the list of all actor IDs.
@@ -122,10 +133,11 @@ export const useSelectedActorId = () =>
 
 /**
  * Hook to get the currently selected actor.
+ * Optimized with O(1) lookup using actorsById.
  */
 export const useSelectedActor = () =>
   useSceneStore((state) =>
-    state.selectedActorId ? state.actors.find((a) => a.id === state.selectedActorId) : undefined
+    state.selectedActorId ? state.actorsById[state.selectedActorId] : undefined
   );
 
 /**

--- a/packages/engine/src/store/slices/actorsSlice.ts
+++ b/packages/engine/src/store/slices/actorsSlice.ts
@@ -8,16 +8,19 @@ export const createActorsSlice: StateCreator<
   ActorsSlice
 > = (set) => ({
   actors: [],
+  actorsById: {},
   selectedActorId: null,
 
   addActor: (actor) =>
     set((state) => {
       state.actors.push(actor);
+      state.actorsById[actor.id] = actor;
     }),
 
   removeActor: (actorId) =>
     set((state) => {
       state.actors = state.actors.filter((a) => a.id !== actorId);
+      delete state.actorsById[actorId];
       if (state.selectedActorId === actorId) {
         state.selectedActorId = null;
       }
@@ -25,9 +28,10 @@ export const createActorsSlice: StateCreator<
 
   updateActor: (actorId, updates) =>
     set((state) => {
-      const actor = state.actors.find((a) => a.id === actorId);
-      if (actor) {
-        Object.assign(actor, updates);
+      const index = state.actors.findIndex((a) => a.id === actorId);
+      if (index !== -1) {
+        Object.assign(state.actors[index], updates);
+        state.actorsById[actorId] = state.actors[index];
       }
     }),
 

--- a/packages/engine/src/store/types.ts
+++ b/packages/engine/src/store/types.ts
@@ -29,6 +29,8 @@ export interface PlaybackState {
 export interface ActorsSlice {
   /** List of actors in the scene. */
   actors: Actor[];
+  /** Normalized map of actors for O(1) lookup. */
+  actorsById: Record<string, Actor>;
   /** The ID of the currently selected actor, or null if none selected. */
   selectedActorId: string | null;
   /** Adds a new actor to the scene. */


### PR DESCRIPTION
Optimized the Zustand store by introducing a normalized `actorsById` lookup map. This improves the performance of actor lookups and reduces unnecessary re-renders for components subscribed to specific actors. 

Key changes:
- Added `actorsById: Record<string, Actor>` to `ActorsSlice`.
- Updated `addActor`, `removeActor`, and `updateActor` to maintain the map.
- Optimized selectors (`getActorById`) and hooks (`useActorById`, `useSelectedActor`) to use O(1) lookups.
- Configured `onRehydrateStorage` to rebuild the map from the persisted `actors` array.
- Excluded `actorsById` from persistence to keep the state lean.
- Updated unit tests to verify the new functionality.

---
*PR created automatically by Jules for task [10461953476733920335](https://jules.google.com/task/10461953476733920335) started by @Fredess74*