### PR TITLE
chore(bundle): size audit

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,36 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-02
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 102 kB | 0 kB | First Load JS (Next.js 15.5.12) |
+| **@Animatica/engine** | 133 kB | +62 kB | Includes index.js (77 kB) and index.cjs (56 kB) |
+| **@Animatica/editor** | 3.4 MB | +3.32 MB | Includes index.js (2.1 MB) and index.cjs (1.3 MB) |
+| **@Animatica/platform** | 0.2 kB | 0 kB | Minimal exports only |
+| **@Animatica/contracts** | 8 kB | 0 kB | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**~3.54 MB** (excluding web), **~3.64 MB** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4 MB)
+- `dist/index.js`: 2.1 MB
+- `dist/index.cjs`: 1.3 MB
+- Note: Significant growth due to inclusion of UI components and editor logic.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (133 kB)
+- `dist/index.js`: 77 kB
+- `dist/index.cjs`: 56 kB
+- Note: Includes core R3F components and animation logic.
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-02.
+- `@Animatica/editor` has grown significantly (from ~76 kB to 3.4 MB) as the full 3-panel layout and property panels were implemented.
+- `@Animatica/engine` nearly doubled in size (from 71 kB to 133 kB) with the addition of more renderers and the bone controller.
+- `apps/web` First Load JS remains stable at 102 kB.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Investigate tree-shaking and lazy loading for large UI components or icons (e.g., `lucide-react`). 2.1 MB for a JS bundle is large for a web application.
+- **@Animatica/engine**: Monitor size as complex humanoid and clothing systems are integrated.
+- **@Animatica/web**: Continue to monitor First Load JS as more feature-rich pages are added.


### PR DESCRIPTION
Performed a bundle size audit of the Animatica monorepo and documented the results in docs/BUNDLE_REPORT.md. Found significant growth in @Animatica/editor (~3.4 MB) and @Animatica/engine (133 kB) since the last audit. @Animatica/web First Load JS remains stable at 102 kB. Reverted unrelated functional and performance metric changes during the process.

---
*PR created automatically by Jules for task [8169172130475362372](https://jules.google.com/task/8169172130475362372) started by @Fredess74*