### PR TITLE
chore(bundle): size audit

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-03
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 110K | +8K | First Load JS (Next.js 15.5) |
+| **@Animatica/engine** | 133K | +62K | index.js (77K) + index.cjs (56K) |
+| **@Animatica/editor** | 3.4M | +3.32M | index.js (2.1M) + index.cjs (1.3M) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports |
+| **@Animatica/contracts** | 4K | -4K | Cache only (no Solidity contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.53M** (excluding web), **3.64M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4M)
+- `dist/index.js`: 2.1M
+- `dist/index.cjs`: 1.3M
+- Note: Significant growth due to Three.js, Lucide-React, and UI components.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (133K)
+- `dist/index.js`: 77K
+- `dist/index.cjs`: 56K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-03.
+- `@Animatica/editor` has grown significantly (from 76K to 3.4M) as the full 3-panel layout and property panels were implemented.
+- `@Animatica/engine` size nearly doubled due to R3F renderer implementations and Zod schemas.
+- `@Animatica/web` First Load JS increased slightly to 110K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Audit large dependencies (Three.js, Lucide-React). Consider code-splitting or tree-shaking optimizations.
+- **@Animatica/engine**: Monitor size as character and clothing systems expand.
+- **@Animatica/web**: 110K is still very healthy for a Next.js application.


### PR DESCRIPTION
Performed a repository-wide bundle size audit.
1. Ran `pnpm build` to generate production artifacts.
2. Analyzed artifact sizes for `@Animatica/engine`, `@Animatica/editor`, `@Animatica/platform`, and `@Animatica/web`.
3. Updated `docs/BUNDLE_REPORT.md` with detailed breakdowns and comparisons to the previous audit.
4. Identified Three.js and UI components as primary drivers for the size increase in the editor package.

---
*PR created automatically by Jules for task [12035497605530382820](https://jules.google.com/task/12035497605530382820) started by @Fredess74*