### PR TITLE
chore(legal): license audit

### DIFF
--- a/docs/LICENSE_AUDIT.md
+++ b/docs/LICENSE_AUDIT.md
@@ -1,6 +1,6 @@
 # License Audit
 
-**Date:** 2026-02-25
+**Date:** 2026-04-05
 **Auditor:** Jules (License Auditor)
 
 ## Summary
@@ -17,17 +17,14 @@ Transitive dependencies: 654
 - **Status:** Present
 - **License:** MIT
 
-## Source Code Headers
-
-- **Checked:** `packages/engine/src/index.ts`
-- **Result:** No license header found.
-
 ## Flagged Licenses (Non-MIT)
 
 The following dependencies have non-MIT licenses:
 
 | Dependency | Version | License | Type |
-| --- | --- | --- |
+| --- | --- | --- | --- |
+| @csstools/color-helpers | 6.0.2 | MIT-0 | Transitive |
+| @csstools/css-syntax-patches-for-csstree | 1.0.28 | MIT-0 | Transitive |
 | @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 | Transitive |
 | @ethereumjs/rlp | 4.0.1 | MPL-2.0 | Transitive |
 | @ethereumjs/util | 8.1.0 | MPL-2.0 | Transitive |
@@ -45,6 +42,7 @@ The following dependencies have non-MIT licenses:
 | @swc/helpers | 0.5.15 | Apache-2.0 | Transitive |
 | @webgpu/types | 0.1.69 | BSD-3-Clause | Transitive |
 | abbrev | 1.0.9 | ISC | Transitive |
+| amdefine | 1.0.1 | BSD-3-Clause OR MIT | Transitive |
 | ansi-align | 3.0.1 | ISC | Transitive |
 | antlr4ts | 0.5.0-alpha.4 | BSD-3-Clause | Transitive |
 | anymatch | 3.1.3 | ISC | Transitive |
@@ -112,6 +110,7 @@ The following dependencies have non-MIT licenses:
 | semver | 5.7.2 | ISC | Transitive |
 | serialize-javascript | 6.0.2 | BSD-3-Clause | Transitive |
 | setprototypeof | 1.2.0 | ISC | Transitive |
+| sha.js | 2.4.12 | (MIT AND BSD-3-Clause) | Transitive |
 | sha1 | 1.1.1 | BSD-3-Clause | Transitive |
 | sharp | 0.34.5 | Apache-2.0 | Transitive |
 | shelljs | 0.8.5 | BSD-3-Clause | Transitive |
@@ -122,10 +121,12 @@ The following dependencies have non-MIT licenses:
 | source-map-js | 1.2.1 | BSD-3-Clause | Transitive |
 | split2 | 3.2.2 | ISC | Transitive |
 | sprintf-js | 1.0.3 | BSD-3-Clause | Transitive |
+| string-format | 2.0.0 | WTFPL OR MIT | Transitive |
 | table | 6.9.0 | BSD-3-Clause | Transitive |
 | tough-cookie | 6.0.0 | BSD-3-Clause | Transitive |
 | ts-command-line-args | 2.5.1 | ISC | Transitive |
 | tslib | 1.14.1 | 0BSD | Transitive |
+| type-fest | 0.7.1 | (MIT OR CC0-1.0) | Transitive |
 | typescript | 5.9.3 | Apache-2.0 | **Direct** |
 | uglify-js | 3.19.3 | BSD-2-Clause | Transitive |
 | web3-utils | 1.10.4 | LGPL-3.0 | Transitive |
@@ -144,7 +145,7 @@ The following dependencies have non-MIT licenses:
 | --- | --- | --- |
 | @nomicfoundation/hardhat-toolbox | MIT | @Animatica/contracts |
 | @openzeppelin/contracts | MIT | @Animatica/contracts |
-| @react-three/drei | MIT | @Animatica/engine |
+| @react-three/drei | MIT | @Animatica/editor, @Animatica/engine |
 | @react-three/fiber | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
 | @tailwindcss/postcss | MIT | @Animatica/editor |
 | @testing-library/dom | MIT | @Animatica/web |
@@ -152,7 +153,7 @@ The following dependencies have non-MIT licenses:
 | @types/node | MIT | @Animatica/engine |
 | @types/react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
 | @types/react-dom | MIT | @Animatica/editor, @Animatica/platform, @Animatica/web |
-| @types/three | MIT | @Animatica/engine |
+| @types/three | MIT | @Animatica/editor, @Animatica/engine |
 | @types/uuid | MIT | @Animatica/engine |
 | @vitejs/plugin-react | MIT | @Animatica/editor |
 | clsx | MIT | @Animatica/editor |
@@ -172,7 +173,7 @@ The following dependencies have non-MIT licenses:
 | uuid | MIT | @Animatica/engine |
 | vite | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform |
 | vitest | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| zod | MIT | @Animatica/engine |
+| zod | MIT | @Animatica/engine, @Animatica/web |
 | zundo | MIT | @Animatica/engine |
 | zustand | MIT | @Animatica/engine |
 
@@ -627,9 +628,9 @@ The following dependencies have non-MIT licenses:
 | lodash.isequal | 4.5.0 | MIT |
 | lodash.truncate | 4.4.2 | MIT |
 | log-symbols | 4.1.0 | MIT |
-| lru_map | 0.3.3 | MIT |
 | lru-cache | 5.1.1 | ISC |
 | lru-cache | 11.2.6 | BlueOak-1.0.0 |
+| lru_map | 0.3.3 | MIT |
 | lucide-react | 0.563.0 | ISC |
 | lz-string | 1.5.0 | MIT |
 | maath | 0.10.8 | MIT |
@@ -771,9 +772,9 @@ The following dependencies have non-MIT licenses:
 | stats.js | 0.17.0 | MIT |
 | statuses | 2.0.2 | MIT |
 | std-env | 3.10.0 | MIT |
-| string_decoder | 1.1.1 | MIT |
 | string-format | 2.0.0 | WTFPL OR MIT |
 | string-width | 2.1.1 | MIT |
+| string_decoder | 1.1.1 | MIT |
 | strip-ansi | 4.0.0 | MIT |
 | strip-hex-prefix | 1.0.0 | MIT |
 | strip-json-comments | 3.1.1 | MIT |
@@ -867,7 +868,7 @@ The following dependencies have non-MIT licenses:
 | yargs-unparser | 2.0.0 | MIT |
 | yn | 3.1.1 | MIT |
 | yocto-queue | 0.1.0 | MIT |
-| zod | 4.3.6 | MIT |
+| zod | 3.25.76 | MIT |
 | zundo | 2.3.0 | MIT |
 | zustand | 4.5.7 | MIT |
 


### PR DESCRIPTION
Updated the license audit documentation in `docs/LICENSE_AUDIT.md`. The update includes:
- Refreshing the audit date to 2026-04-05.
- Scanning all workspace `package.json` files for direct dependencies.
- Gathering a comprehensive list of all dependencies (direct and transitive) and their licenses using `pnpm licenses list`.
- Identifying and flagging all non-MIT dependencies (e.g., Apache-2.0, BSD-3-Clause, ISC, etc.).
- Categorizing direct dependencies by the workspace packages that use them.
- Providing a full, searchable list of all project dependencies in a collapsible section.

All temporary processing scripts and raw data files were removed, and unrelated changes to performance benchmarks were reverted.

---
*PR created automatically by Jules for task [5344051572404937179](https://jules.google.com/task/5344051572404937179) started by @Fredess74*