### PR TITLE
chore(bundle): size audit and optimization

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,33 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-05
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 110K | +8K | First Load JS |
+| **@Animatica/engine** | 135.4K | +64.4K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 180.9K | +104.9K | Includes index.js (109.5K) and index.cjs (71.4K) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**324.5K** (excluding web), **434.5K** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (180.9K)
+- `dist/index.js`: 109.5K
+- `dist/index.cjs`: 71.4K
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-05.
+- Fixed a major regression in `@Animatica/editor` by externalizing `three`, `@react-three/fiber`, and `@react-three/drei`. Size reduced from ~3.5MB to 180.9K.
+- `@Animatica/engine` size has doubled since the last audit as more renderers and logic were added.
+- `@Animatica/web` First Load JS increased slightly to 110K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/engine**: Monitor size closely; consider code-splitting if it exceeds 250K.
+- **@Animatica/web**: Perform a `next-bundle-analyzer` run to identify what's contributing to the 110K baseline.

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
                 'react',
                 'react-dom',
                 '@Animatica/engine',
+                'three',
+                '@react-three/fiber',
+                '@react-three/drei',
                 'lucide-react',
                 'clsx',
                 'tailwind-merge'


### PR DESCRIPTION
This PR performs a bundle size audit for the Animatica monorepo.

Key changes:
1.  **Audit Report**: Created/Updated `docs/BUNDLE_REPORT.md` with current sizes for all packages, providing comparisons to the previous audit and identifying growth areas.
2.  **Size Optimization**: Identified a major size regression in `@Animatica/editor` where Three.js and related libraries were being bundled instead of being treated as external dependencies.
3.  **Fix**: Updated `packages/editor/vite.config.ts` to correctly externalize `three`, `@react-three/fiber`, and `@react-three/drei`. This reduced the editor's bundle size from approximately 3.5MB to 181kB.

Note: Some pre-existing test failures in `Viewport.test.tsx` and `CharacterRenderer.test.tsx` were observed but are unrelated to these changes and were present in the base branch.

---
*PR created automatically by Jules for task [7210618403035066000](https://jules.google.com/task/7210618403035066000) started by @Fredess74*