### PR TITLE
feat(engine): implement BoneController for character pose overrides (#12)

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+    boneNames.forEach(name => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+    controller = new BoneController(bones)
+  })
+
+  it('maps pose to bones correctly', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      leftArm: [Math.PI / 2, 0, 0]
+    }
+
+    controller.updatePose(pose)
+    // Update with delta large enough to complete lerp immediately (10.0 * 0.1 = 1.0)
+    controller.update(0.1)
+
+    const headBone = bones.get('Head')!
+    const expectedHeadEuler = new THREE.Euler(0.1, 0.2, 0.3)
+    const expectedHeadQuat = new THREE.Quaternion().setFromEuler(expectedHeadEuler)
+
+    expect(headBone.quaternion.x).toBeCloseTo(expectedHeadQuat.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expectedHeadQuat.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expectedHeadQuat.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expectedHeadQuat.w)
+
+    const leftArmBone = bones.get('LeftArm')!
+    expect(leftArmBone.quaternion.x).toBeCloseTo(Math.sin(Math.PI / 4))
+    expect(leftArmBone.quaternion.w).toBeCloseTo(Math.cos(Math.PI / 4))
+  })
+
+  it('interpolates rotations over time', () => {
+    const pose: BodyPose = {
+      head: [Math.PI, 0, 0]
+    }
+
+    controller.updatePose(pose)
+
+    // Halfway (lerpSpeed = 10.0, delta = 0.05 => 0.5)
+    // Note: Slerp is not linear on components but we expect movement
+    controller.update(0.05)
+
+    const headBone = bones.get('Head')!
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+    expect(headBone.quaternion.x).toBeLessThan(1.0)
+
+    // Finish (another 0.1s to be sure it reaches 1.0)
+    controller.update(0.1)
+    expect(headBone.quaternion.x).toBeCloseTo(1.0)
+    expect(headBone.quaternion.w).toBeCloseTo(0)
+  })
+
+  it('handles missing bones gracefully', () => {
+    const limitedBones = new Map<string, THREE.Bone>()
+    const headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    limitedBones.set('Head', headBone)
+
+    const limitedController = new BoneController(limitedBones)
+    const pose: BodyPose = {
+      head: [1, 0, 0],
+      spine: [0, 1, 0] // Missing in map
+    }
+
+    expect(() => {
+      limitedController.updatePose(pose)
+      limitedController.update(0.1)
+    }).not.toThrow()
+
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+  })
+
+  it('resets bones to identity', () => {
+    const pose: BodyPose = {
+      head: [1, 1, 1]
+    }
+    controller.updatePose(pose)
+    controller.update(0.1)
+
+    controller.reset()
+    const headBone = bones.get('Head')!
+    expect(headBone.quaternion.x).toBe(0)
+    expect(headBone.quaternion.y).toBe(0)
+    expect(headBone.quaternion.z).toBe(0)
+    expect(headBone.quaternion.w).toBe(1)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three'
+import type { BodyPose, Vector3 } from '../types'
+
+/**
+ * BoneController — Maps abstract BodyPose properties to Three.js bones.
+ * Handles smooth interpolation of bone rotations to avoid snapping.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targetQuaternions: Map<string, THREE.Quaternion> = new Map()
+  private currentQuaternions: Map<string, THREE.Quaternion> = new Map()
+  private lerpSpeed: number = 10.0 // units per second
+
+  /**
+   * Mapping from BodyPose keys to actual humanoid bone names.
+   */
+  private static readonly BONE_MAP: Record<keyof BodyPose, string> = {
+    head: 'Head',
+    spine: 'Spine',
+    leftArm: 'LeftArm',
+    rightArm: 'RightArm',
+    leftLeg: 'LeftUpperLeg',
+    rightLeg: 'RightUpperLeg',
+  }
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+
+    // Initialize quaternions for mapped bones
+    for (const boneName of Object.values(BoneController.BONE_MAP)) {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        this.targetQuaternions.set(boneName, bone.quaternion.clone())
+        this.currentQuaternions.set(boneName, bone.quaternion.clone())
+      }
+    }
+  }
+
+  /**
+   * Updates the target pose. Rotations are expected as Euler angles in radians.
+   * @param pose The new body pose overrides.
+   */
+  updatePose(pose?: BodyPose): void {
+    if (!pose) return
+
+    for (const [poseKey, rotation] of Object.entries(pose)) {
+      const boneName = BoneController.BONE_MAP[poseKey as keyof BodyPose]
+      if (!boneName || !rotation) continue
+
+      const targetQuat = this.targetQuaternions.get(boneName)
+      if (targetQuat) {
+        const euler = new THREE.Euler(...(rotation as Vector3))
+        targetQuat.setFromEuler(euler)
+      }
+    }
+  }
+
+  /**
+   * Smoothly interpolates bone rotations towards target values.
+   * Should be called in the rendering loop.
+   * @param delta Time since last frame in seconds.
+   */
+  update(delta: number): void {
+    const step = this.lerpSpeed * delta
+
+    for (const [boneName, targetQuat] of this.targetQuaternions.entries()) {
+      const currentQuat = this.currentQuaternions.get(boneName)
+      const bone = this.bones.get(boneName)
+
+      if (currentQuat && bone) {
+        // Slerp current towards target
+        currentQuat.slerp(targetQuat, Math.min(step, 1.0))
+        // Apply to actual bone
+        bone.quaternion.copy(currentQuat)
+      }
+    }
+  }
+
+  /**
+   * Resets all controlled bones to their default (usually identity) rotation.
+   */
+  reset(): void {
+    for (const boneName of Object.values(BoneController.BONE_MAP)) {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        bone.quaternion.set(0, 0, 0, 1)
+        this.targetQuaternions.get(boneName)?.set(0, 0, 0, 1)
+        this.currentQuaternions.get(boneName)?.set(0, 0, 0, 1)
+      }
+    }
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -14,6 +14,8 @@ export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 export { EyeController } from './EyeController'
 export type { EyeState } from './EyeController'
 
+export { BoneController } from './BoneController'
+
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -35,6 +36,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 }) => {
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
@@ -68,6 +70,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
     faceMorphRef.current = faceMorph
 
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    boneController.updatePose(actor.bodyPose)
+    boneControllerRef.current = boneController
+
     // Setup eye controller
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
@@ -91,6 +98,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.animationSpeed])
 
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current) {
+      boneControllerRef.current.updatePose(actor.bodyPose)
+    }
+  }, [actor.bodyPose])
+
   // React to morph target / expression changes from CharacterPanel
   useEffect(() => {
     if (faceMorphRef.current && actor.morphTargets) {
@@ -103,6 +117,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Apply body pose overrides on top of animation
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending


### PR DESCRIPTION
Implemented the BoneController class to map BodyPose properties to Three.js bones with smooth interpolation. Integrated the controller into CharacterRenderer to allow programmatic pose overrides on top of animations. Added comprehensive unit tests.

---
*PR created automatically by Jules for task [17036405885535264681](https://jules.google.com/task/17036405885535264681) started by @Fredess74*