### PR TITLE
chore(bundle): size audit and optimization

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,44 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report
 
-## Package Sizes
+**Date:** April 9, 2026
+**Commit Message:** chore(bundle): size audit
 
-| Package | Size | Comparison | Notes |
-| :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+## Summary
 
-## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+This report provides a breakdown of the bundle sizes for all packages and applications within the Animatica monorepo.
 
-## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+## Packages
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+| Package | Format | Size (Raw) | Size (Gzip) |
+|---------|--------|------------|-------------|
+| `@Animatica/platform` | ESM | 0.06 kB | 0.08 kB |
+| | CJS | 0.12 kB | 0.14 kB |
+| `@Animatica/engine` | ESM | 78.78 kB | 22.25 kB |
+| | CJS | 56.64 kB | 18.89 kB |
+| `@Animatica/editor` | ESM | 109.48 kB | 25.42 kB |
+| | CJS | 71.44 kB | 21.56 kB |
 
-## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+> **Note:** Externalized `three`, `@react-three/fiber`, and `@react-three/drei` in `@Animatica/editor` to reduce bundle size from ~2.2 MB to ~109 kB.
 
-## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+## Applications
+
+### `@Animatica/web` (Next.js)
+
+| Route | Size | First Load JS |
+|-------|------|---------------|
+| `/` | 4.87 kB | 110 kB |
+| `/_not-found` | 998 B | 103 kB |
+| `/api/auth` | 137 B | 102 kB |
+| `/api/export` | 137 B | 102 kB |
+| `/api/generate` | 137 B | 102 kB |
+| `/api/projects` | 137 B | 102 kB |
+| `/api/projects/[id]` | 137 B | 102 kB |
+| `/editor` | 1.49 kB | 104 kB |
+| `/login` | 164 B | 106 kB |
+| `/signup` | 164 B | 106 kB |
+
+**Shared Chunks:**
+- First Load JS shared by all: 102 kB
+- `chunks/743-33720d133c383396.js`: 45.7 kB
+- `chunks/8e6518bb-c26e82767f1faf66.js`: 54.2 kB
+- Other shared chunks: 2.09 kB

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
             external: [
                 'react',
                 'react-dom',
+                'three',
+                '@react-three/fiber',
+                '@react-three/drei',
                 '@Animatica/engine',
                 'lucide-react',
                 'clsx',


### PR DESCRIPTION
Audited the bundle sizes of all packages and applications in the monorepo. During the audit, identified that @Animatica/editor was excessively large (~2.2 MB) due to including Three.js and its related libraries. Fixed this by adding them to the external list in the Vite configuration, which reduced the ESM bundle to ~109 KB. Generated a comprehensive report in docs/BUNDLE_REPORT.md.

---
*PR created automatically by Jules for task [7363060624128518686](https://jules.google.com/task/7363060624128518686) started by @Fredess74*