### PR TITLE
feat(engine): implement BoneController for skeletal posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { BoneController } from './BoneController';
+import { BodyPose } from '../types';
+
+describe('BoneController', () => {
+    let bones: Map<string, THREE.Bone>;
+    let controller: BoneController;
+
+    beforeEach(() => {
+        bones = new Map();
+        const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg'];
+        boneNames.forEach(name => {
+            const bone = new THREE.Bone();
+            bone.name = name;
+            bones.set(name, bone);
+        });
+        controller = new BoneController(bones);
+    });
+
+    it('should map BodyPose to correct bones', () => {
+        const pose: BodyPose = {
+            head: [0.1, 0.2, 0.3],
+            spine: [0.4, 0.5, 0.6],
+        };
+
+        controller.setImmediate(pose);
+
+        const headBone = bones.get('Head');
+        const spineBone = bones.get('Spine');
+
+        expect(headBone?.rotation.x).toBeCloseTo(0.1);
+        expect(headBone?.rotation.y).toBeCloseTo(0.2);
+        expect(headBone?.rotation.z).toBeCloseTo(0.3);
+
+        expect(spineBone?.rotation.x).toBeCloseTo(0.4);
+        expect(spineBone?.rotation.y).toBeCloseTo(0.5);
+        expect(spineBone?.rotation.z).toBeCloseTo(0.6);
+    });
+
+    it('should interpolate towards target pose', () => {
+        const pose: BodyPose = {
+            leftArm: [1, 1, 1],
+        };
+
+        controller.setPose(pose);
+
+        // Update with delta time
+        // lerpSpeed is 8.0, delta is 0.05 -> alpha = 0.4
+        controller.update(0.05);
+
+        const leftArmBone = bones.get('LeftArm');
+        expect(leftArmBone?.rotation.x).toBeCloseTo(0.4);
+        expect(leftArmBone?.rotation.y).toBeCloseTo(0.4);
+        expect(leftArmBone?.rotation.z).toBeCloseTo(0.4);
+
+        // Update again to reach target
+        controller.update(1.0);
+        expect(leftArmBone?.rotation.x).toBeCloseTo(1);
+    });
+
+    it('should handle missing bones gracefully', () => {
+        const incompleteBones = new Map<string, THREE.Bone>();
+        const headBone = new THREE.Bone();
+        headBone.name = 'Head';
+        incompleteBones.set('Head', headBone);
+
+        const partialController = new BoneController(incompleteBones);
+        const pose: BodyPose = {
+            head: [0.1, 0.1, 0.1],
+            leftArm: [1, 1, 1], // Bone missing
+        };
+
+        expect(() => {
+            partialController.setImmediate(pose);
+        }).not.toThrow();
+
+        expect(headBone.rotation.x).toBeCloseTo(0.1);
+    });
+
+    it('should reset pose overrides', () => {
+        const pose: BodyPose = {
+            rightLeg: [0.5, 0.5, 0.5],
+        };
+
+        controller.setImmediate(pose);
+        controller.reset();
+
+        // After reset, calling update shouldn't change anything (no targetPose)
+        const rightLegBone = bones.get('RightUpperLeg');
+        const initialRotation = rightLegBone?.rotation.x || 0;
+
+        controller.setPose({ rightLeg: [1, 1, 1] });
+        controller.reset();
+        controller.update(0.1);
+
+        expect(rightLegBone?.rotation.x).toBe(initialRotation);
+    });
+});

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,128 @@
+/**
+ * BoneController — Controls individual bone rotations for skeletal posing.
+ * Maps abstract BodyPose properties to specific humanoid bones and handles smooth interpolation.
+ *
+ * @module @animatica/engine/character
+ */
+import * as THREE from 'three';
+import type { BodyPose } from '../types';
+
+/**
+ * Mapping between BodyPose properties and standard humanoid bone names.
+ */
+const BONE_MAPPING: Record<keyof BodyPose, string> = {
+    head: 'Head',
+    spine: 'Spine',
+    leftArm: 'LeftArm',
+    rightArm: 'RightArm',
+    leftLeg: 'LeftUpperLeg',
+    rightLeg: 'RightUpperLeg',
+};
+
+/**
+ * BoneController manages the skeletal pose of a character.
+ * It allows overriding specific bone rotations on top of animations.
+ */
+export class BoneController {
+    private bones: Map<string, THREE.Bone>;
+    private targetPose: BodyPose = {};
+    private currentPose: BodyPose = {};
+    private lerpSpeed: number = 8.0;
+
+    /**
+     * @param bones A map of bone names to THREE.Bone instances.
+     */
+    constructor(bones: Map<string, THREE.Bone>) {
+        this.bones = bones;
+    }
+
+    /**
+     * Set the target pose for the character.
+     * The controller will smoothly interpolate towards this pose in the update loop.
+     * @param pose The new body pose to apply.
+     */
+    setPose(pose: BodyPose): void {
+        // Deep copy incoming pose to prevent external mutation issues
+        this.targetPose = JSON.parse(JSON.stringify(pose));
+    }
+
+    /**
+     * Set the pose immediately without interpolation.
+     * @param pose The body pose to apply.
+     */
+    setImmediate(pose: BodyPose): void {
+        this.targetPose = { ...pose };
+        this.currentPose = JSON.parse(JSON.stringify(pose)); // Deep copy to avoid reference sharing
+        this.applyPose(this.currentPose);
+    }
+
+    /**
+     * Update the bone rotations based on the current target pose and delta time.
+     * Should be called every frame.
+     * @param delta Time elapsed since the last frame in seconds.
+     */
+    update(delta: number): void {
+        const alpha = Math.min(delta * this.lerpSpeed, 1.0);
+        let hasChanges = false;
+
+        // Interpolate each defined pose component
+        for (const key of Object.keys(BONE_MAPPING) as Array<keyof BodyPose>) {
+            const target = this.targetPose[key];
+            if (!target) continue;
+
+            if (!this.currentPose[key]) {
+                this.currentPose[key] = [0, 0, 0];
+            }
+
+            const current = this.currentPose[key]!;
+
+            // Lerp each axis
+            for (let i = 0; i < 3; i++) {
+                const diff = target[i] - current[i];
+                if (Math.abs(diff) > 0.0001) {
+                    current[i] += diff * alpha;
+                    hasChanges = true;
+                } else {
+                    current[i] = target[i];
+                }
+            }
+        }
+
+        if (hasChanges) {
+            this.applyPose(this.currentPose);
+        }
+    }
+
+    /**
+     * Reset all bone overrides.
+     */
+    reset(): void {
+        this.targetPose = {};
+        this.currentPose = {};
+        // Note: We don't reset bone rotations to 0 here because they might be driven by animations.
+        // The controller simply stops applying overrides.
+    }
+
+    /**
+     * Apply the given pose to the bones.
+     */
+    private applyPose(pose: BodyPose): void {
+        for (const [prop, boneName] of Object.entries(BONE_MAPPING)) {
+            const rotation = pose[prop as keyof BodyPose];
+            if (rotation) {
+                const bone = this.bones.get(boneName);
+                if (bone) {
+                    bone.rotation.set(rotation[0], rotation[1], rotation[2]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set the interpolation speed.
+     * @param speed Units per second (default: 8.0).
+     */
+    setLerpSpeed(speed: number): void {
+        this.lerpSpeed = speed;
+    }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -14,6 +14,8 @@ export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 export { EyeController } from './EyeController'
 export type { EyeState } from './EyeController'
 
+export { BoneController } from './BoneController'
+
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -9,9 +9,16 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: (val: any) => ({ current: val }),
+    useMemo: (fn: any) => fn(),
+    useEffect: () => {},
   }
 })
+
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: () => {},
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
@@ -39,11 +46,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing character rig with correct transform', () => {
+    // Call the functional component directly
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +61,27 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Rig root should be rendered as a primitive
+    const rigPrimitive = children.find((c: any) => c.type === 'primitive')
+    expect(rigPrimitive).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    // As per CharacterRenderer implementation: visible={actor.visible}
+    // and if (!actor.visible) return null; was missing in previous turn, but let's check.
+    // Memory says: In CharacterRenderer.tsx, the component must return null if actor.visible is false
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection ring when isSelected is true', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Selection ring should be present
+    const selectionRing = children.find((c: any) => c.type === 'mesh' && c.props.children?.[0]?.type === 'ringGeometry')
+    expect(selectionRing).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -72,6 +74,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
 
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    if (actor.bodyPose) {
+      boneController.setImmediate(actor.bodyPose)
+    }
+    boneControllerRef.current = boneController
+
     return () => {
       animator.dispose()
     }
@@ -98,11 +107,25 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.morphTargets])
 
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setPose(actor.bodyPose)
+    }
+  }, [actor.bodyPose])
+
+  if (!actor.visible) return null
+
   // Frame update — animation, face morphs, eye blinks
   useFrame((_state, delta) => {
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Body pose overriding
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending


### PR DESCRIPTION
This PR implements the BoneController in the @Animatica/engine package. The BoneController maps BodyPose properties to specific humanoid bones and handles smooth interpolation. It is integrated into the CharacterRenderer to allow for manual character posing on top of animations.

---
*PR created automatically by Jules for task [6651272821085575995](https://jules.google.com/task/6651272821085575995) started by @Fredess74*