### PR TITLE
fix(engine): resolve CharacterRenderer visibility bug and test regression

### DIFF
--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,13 +8,15 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +40,10 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
+  it('renders a group containing primitive rig with correct transform', () => {
+    // Call the component function directly
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +56,31 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // First child should be the primitive rig
+    const rigPrimitive = children[0] as React.ReactElement
+    expect(rigPrimitive.type).toBe('primitive')
+    expect((rigPrimitive.props as any).object).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
+  it('renders selection ring when isSelected is true', () => {
      // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Second child should be the selection ring mesh
+    const selectionRing = children[1] as React.ReactElement
+    expect(selectionRing).toBeDefined()
+    expect(selectionRing.type).toBe('mesh')
+
+    const meshChildren = React.Children.toArray((selectionRing.props as any).children) as React.ReactElement[]
+    expect(meshChildren.some(child => child.type === 'ringGeometry')).toBe(true)
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -121,6 +121,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   })
 
+  if (!actor.visible) return null
+
   return (
     <group
       ref={groupRef}


### PR DESCRIPTION
This PR fixes a bug in `CharacterRenderer` where it didn't correctly handle the `visible` prop with an early return, and resolves a significant test regression in `@Animatica/engine`.

Key changes:
- Added a visibility check `if (!actor.visible) return null` in `CharacterRenderer.tsx` after all React hooks to comply with the Rules of Hooks.
- Completely refactored `CharacterRenderer.test.tsx` to support testing the functional component via direct invocation. This involved mocking `useMemo`, `useEffect`, `useRef`, and `useFrame`.
- Resolved a `TypeError` in tests caused by trying to access `.type.render` on the component.
- Updated test expectations to align with the current implementation which renders a character rig via a `<primitive>` element instead of a placeholder capsule.
- Verified that all 144 tests in the engine package pass and the entire monorepo builds successfully.

---
*PR created automatically by Jules for task [17259017584309087695](https://jules.google.com/task/17259017584309087695) started by @Fredess74*