### PR TITLE
Bundle Size Audit and Regression Fix - 2026-04-13

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-13
 
 ## Package Sizes
 
-| Package | Size | Comparison | Notes |
+| Package | Size (JS + CJS) | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 110K | +8K | First Load JS (Next.js 15) |
+| **@Animatica/engine** | 135.4K | +64.4K | index.js (78.8K) + index.cjs (56.6K) |
+| **@Animatica/editor** | 177.3K | +101.3K | index.js (107K) + index.cjs (70.3K) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports |
+| **@Animatica/contracts** | 0K | -8K | No compiled artifacts |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**~313K** (excluding web), **~423K** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (177.3K)
+- `dist/index.js`: 107K
+- `dist/index.cjs`: 70.3K
+- **Status:** Resolved. A previous regression caused `three` and R3F to be bundled. These are now correctly externalized.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Audit for 2026-04-13.
+- **Fixed Regression:** `@Animatica/editor` bundle size was reduced from ~3.4MB to ~180K by externalizing `three`, `@react-three/fiber`, and `@react-three/drei` in `vite.config.ts`.
+- `@Animatica/engine` size has increased as more core features (Task 6, 21) were implemented.
+- `@Animatica/web` First Load JS remains healthy at 110K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Ensure any new R3F dependencies are added to the `external` list in `vite.config.ts`.
+- **@Animatica/engine**: Continue monitoring; current growth is expected given feature additions, but ensure peer dependencies remain external.

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
             external: [
                 'react',
                 'react-dom',
+                'three',
+                '@react-three/fiber',
+                '@react-three/drei',
                 '@Animatica/engine',
                 'lucide-react',
                 'clsx',


### PR DESCRIPTION
Updated the bundle size report for 2026-04-13 and fixed a critical size regression in the @Animatica/editor package. The regression was caused by three, @react-three/fiber, and @react-three/drei being accidentally bundled into the library; they are now correctly externalized in the Vite configuration. Overall bundle size (excluding web) was reduced from ~3.6M to ~313K.

---
*PR created automatically by Jules for task [10501795483964952808](https://jules.google.com/task/10501795483964952808) started by @Fredess74*