### PR TITLE
feat(engine): implement BoneController for skeletal posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import type { CharacterRig } from './CharacterLoader'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let rig: CharacterRig
+  let controller: BoneController
+  let bones: Map<string, THREE.Bone>
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+
+    boneNames.forEach(name => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+
+    rig = {
+      root: new THREE.Group(),
+      bodyMesh: null,
+      skeleton: null,
+      bones,
+      morphTargetMap: {},
+      animations: []
+    }
+
+    controller = new BoneController(rig)
+  })
+
+  it('should apply rotation to mapped bones', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      leftArm: [1.0, 0, 0]
+    }
+
+    controller.setPose(pose)
+
+    const head = bones.get('Head')!
+    expect(head.rotation.x).toBeCloseTo(0.1)
+    expect(head.rotation.y).toBeCloseTo(0.2)
+    expect(head.rotation.z).toBeCloseTo(0.3)
+
+    const leftArm = bones.get('LeftArm')!
+    expect(leftArm.rotation.x).toBeCloseTo(1.0)
+    expect(leftArm.rotation.y).toBe(0)
+    expect(leftArm.rotation.z).toBe(0)
+  })
+
+  it('should handle missing bones gracefully', () => {
+    // Create a rig with only head bone
+    const headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    const minimalBones = new Map([['Head', headBone]])
+
+    const minimalRig: CharacterRig = {
+      ...rig,
+      bones: minimalBones
+    }
+
+    const minimalController = new BoneController(minimalRig)
+
+    const pose: BodyPose = {
+      head: [0.1, 0, 0],
+      leftArm: [1.0, 0, 0] // Bone missing in rig
+    }
+
+    // Should not throw
+    expect(() => minimalController.setPose(pose)).not.toThrow()
+    expect(headBone.rotation.x).toBeCloseTo(0.1)
+  })
+
+  it('should reset bones to identity rotation', () => {
+    const pose: BodyPose = {
+      head: [1, 1, 1],
+      spine: [0.5, 0.5, 0.5]
+    }
+
+    controller.setPose(pose)
+    controller.reset()
+
+    bones.forEach(bone => {
+      expect(bone.quaternion.x).toBe(0)
+      expect(bone.quaternion.y).toBe(0)
+      expect(bone.quaternion.z).toBe(0)
+      expect(bone.quaternion.w).toBe(1)
+    })
+  })
+
+  it('should map leftLeg and rightLeg to UpperLeg bones', () => {
+    const pose: BodyPose = {
+      leftLeg: [0.5, 0, 0],
+      rightLeg: [0, 0.5, 0]
+    }
+
+    controller.setPose(pose)
+
+    const leftLeg = bones.get('LeftUpperLeg')!
+    expect(leftLeg.rotation.x).toBeCloseTo(0.5)
+
+    const rightLeg = bones.get('RightUpperLeg')!
+    expect(rightLeg.rotation.y).toBeCloseTo(0.5)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,69 @@
+import * as THREE from 'three'
+import type { BodyPose, Vector3 } from '../types'
+import type { CharacterRig } from './CharacterLoader'
+
+/**
+ * BoneController — Manages skeletal posing for character actors.
+ * Maps the high-level BodyPose interface to specific Three.js bones.
+ *
+ * Supports:
+ * - Direct rotation application from BodyPose
+ * - Graceful handling of missing bones
+ * - Resetting to default bind pose
+ *
+ * @module @animatica/engine/character
+ */
+export class BoneController {
+    private bones: Map<string, THREE.Bone>
+
+    constructor(rig: CharacterRig) {
+        this.bones = rig.bones
+    }
+
+    /**
+     * Applies a BodyPose to the character's skeleton.
+     * Rotations are expected to be Euler angles in radians.
+     *
+     * @param pose The body pose to apply.
+     */
+    setPose(pose: BodyPose): void {
+        if (pose.head) this.applyRotation('Head', pose.head)
+        if (pose.spine) this.applyRotation('Spine', pose.spine)
+        if (pose.leftArm) this.applyRotation('LeftArm', pose.leftArm)
+        if (pose.rightArm) this.applyRotation('RightArm', pose.rightArm)
+        if (pose.leftLeg) this.applyRotation('LeftUpperLeg', pose.leftLeg)
+        if (pose.rightLeg) this.applyRotation('RightUpperLeg', pose.rightLeg)
+    }
+
+    /**
+     * Resets all pose-controllable bones to identity rotation.
+     */
+    reset(): void {
+        const poseBones = [
+            'Head',
+            'Spine',
+            'LeftArm',
+            'RightArm',
+            'LeftUpperLeg',
+            'RightUpperLeg',
+        ]
+
+        poseBones.forEach((name) => {
+            const bone = this.bones.get(name)
+            if (bone) {
+                bone.quaternion.set(0, 0, 0, 1)
+            }
+        })
+    }
+
+    /**
+     * Internal helper to apply rotation to a named bone.
+     */
+    private applyRotation(boneName: string, rotation: Vector3): void {
+        const bone = this.bones.get(boneName)
+        if (bone) {
+            // BodyPose uses [x, y, z] Euler angles
+            bone.rotation.set(rotation[0], rotation[1], rotation[2])
+        }
+    }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -14,6 +14,8 @@ export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 export { EyeController } from './EyeController'
 export type { EyeState } from './EyeController'
 
+export { BoneController } from './BoneController'
+
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,26 +1,74 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
-// Mock react to bypass hooks checks when calling component directly
+// Mock Three.js group and other elements used by R3F
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
+
+// Mock our character-related controllers and loaders to keep tests light
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: { name: 'rig-root' },
+    bodyMesh: null,
+    morphTargetMap: {},
+  })),
+}))
+
+vi.mock('../../character/CharacterAnimator', () => ({
+  CharacterAnimator: vi.fn(() => ({
+    registerClip: vi.fn(),
+    play: vi.fn(),
+    update: vi.fn(),
+    dispose: vi.fn(),
+    setSpeed: vi.fn(),
+  })),
+  createIdleClip: vi.fn(),
+  createWalkClip: vi.fn(),
+  createRunClip: vi.fn(),
+  createTalkClip: vi.fn(),
+  createWaveClip: vi.fn(),
+  createDanceClip: vi.fn(),
+  createSitClip: vi.fn(),
+  createJumpClip: vi.fn(),
+}))
+
+vi.mock('../../character/FaceMorphController', () => ({
+  FaceMorphController: vi.fn(() => ({
+    setTarget: vi.fn(),
+    update: vi.fn(),
+  })),
+}))
+
+vi.mock('../../character/EyeController', () => ({
+  EyeController: vi.fn(() => ({
+    update: vi.fn(),
+  })),
+}))
+
+vi.mock('../../character/BoneController', () => ({
+  BoneController: vi.fn(() => ({
+    setPose: vi.fn(),
+  })),
+}))
+
+// Mock React to provide stable mock hooks for all tests
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
   }
 })
-
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
-}))
 
 describe('CharacterRenderer', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   const mockActor: CharacterActor = {
@@ -39,64 +87,29 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing the rig root with correct transform', () => {
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
-    expect(result).not.toBeNull()
     expect(result.type).toBe('group')
+    expect(result.props.position).toEqual([10, 0, 5])
 
-    const props = result.props as any
-    expect(props.position).toEqual([10, 0, 5])
-    expect(props.rotation).toEqual([0, Math.PI, 0])
-    expect(props.scale).toEqual([1, 1, 1])
-
-    // Verify children
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    const children = React.Children.toArray(result.props.children) as React.ReactElement[]
+    expect(children[0].type).toBe('primitive')
+    expect(children[0].props.object.name).toBe('rig-root')
   })
 
-  it('renders nothing when visible is false', () => {
+  it('returns null when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
+  it('renders a selection ring when isSelected is true', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
+    const children = React.Children.toArray(result.props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // children[0] is rig root, children[1] should be the selection ring
+    const selectionRing = children[1]
+    expect(selectionRing.type).toBe('mesh')
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -72,6 +74,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
 
+    // Setup bone controller
+    const boneController = new BoneController(rig)
+    boneControllerRef.current = boneController
+
     return () => {
       animator.dispose()
     }
@@ -98,14 +104,21 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.morphTargets])
 
-  // Frame update — animation, face morphs, eye blinks
+  if (!actor.visible) return null
+
+  // Frame update — animation, face morphs, eye blinks, and custom pose
   useFrame((_state, delta) => {
-    // Skeletal animation
+    // 1. Skeletal animation (e.g. idle/walk)
     if (animatorRef.current) {
       animatorRef.current.update(delta)
     }
 
-    // Face morph blending
+    // 2. Custom bone pose (overrides or augments animation)
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setPose(actor.bodyPose)
+    }
+
+    // 3. Face morph blending
     if (faceMorphRef.current) {
       faceMorphRef.current.update(delta)
     }


### PR DESCRIPTION
This PR implements Task 12: Bone Controller from the engine backlog. It adds the `BoneController` class to `packages/engine/src/character/BoneController.ts`, which maps the high-level `BodyPose` interface to specific Three.js bones in a character rig.

Key changes:
- `BoneController` class handles rotation application from `BodyPose` (Euler angles) to bones like Head, Spine, LeftArm, etc.
- `CharacterRenderer` now utilizes `BoneController` within its `useFrame` loop to ensure custom poses are applied after animations, allowing for procedural posing on top of or instead of active animations.
- Comprehensive unit tests added in `BoneController.test.ts`.
- `CharacterRenderer.test.tsx` refactored to use more surgical mocks and fix regressions.

This implementation allows users to control character skeletal poses through the `bodyPose` property in the scene store.

---
*PR created automatically by Jules for task [3969750787125975149](https://jules.google.com/task/3969750787125975149) started by @Fredess74*