### PR TITLE
feat(engine): implement BoneController for character posing (#12)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -73,9 +73,9 @@ This document tracks all open tasks, issues, and feature requests for the Animat
 - **Type:** Feature (Character)
 - **Description:** Implement `BoneController.ts` to map the abstract `bodyPose` object to actual skeleton bone rotations (head, spine, leftArm, rightArm, leftLeg, rightLeg).
 - **Acceptance Criteria:**
-  - [ ] Function to traverse the GLTF skeleton and find relevant bones.
-  - [ ] Applies rotations from `bodyPose` to the bones.
-  - [ ] Smoothly interpolates updates if needed.
+  - [x] Function to traverse the GLTF skeleton and find relevant bones.
+  - [x] Applies rotations from `bodyPose` to the bones.
+  - [x] Smoothly interpolates updates if needed.
 
 ### [Task 13] Feat: Morph Targets
 - **Priority:** Medium

--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  const createMockBone = (name: string) => {
+    const bone = new THREE.Bone()
+    bone.name = name
+    return bone
+  }
+
+  it('should apply rotation to bones when setPose is called', () => {
+    const headBone = createMockBone('Head')
+    const bones = new Map<string, THREE.Bone>([['Head', headBone]])
+    const controller = new BoneController(bones)
+
+    const pose: BodyPose = {
+      head: [Math.PI / 4, 0, 0],
+    }
+
+    controller.setPose(pose)
+    // Update with delta = 1 to ensure it completes slerp if speed is high enough
+    // but slerp(target, 1 * 5) will definitely hit the target.
+    controller.update(1)
+
+    // Check if the bone's quaternion roughly matches the target rotation
+    const expectedQuat = new THREE.Quaternion().setFromEuler(
+      new THREE.Euler(Math.PI / 4, 0, 0)
+    )
+
+    expect(headBone.quaternion.x).toBeCloseTo(expectedQuat.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expectedQuat.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expectedQuat.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expectedQuat.w)
+  })
+
+  it('should interpolate towards the target pose over multiple updates', () => {
+    const headBone = createMockBone('Head')
+    const bones = new Map<string, THREE.Bone>([['Head', headBone]])
+    const controller = new BoneController(bones)
+
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+
+    controller.setPose(pose)
+
+    // Small delta should move it partially
+    controller.update(0.01)
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+    expect(headBone.quaternion.x).toBeLessThan(new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)).x)
+
+    // Large delta or multiple updates should reach target
+    controller.update(1.0)
+    const targetQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0))
+    expect(headBone.quaternion.x).toBeCloseTo(targetQuat.x)
+  })
+
+  it('should handle missing bones gracefully', () => {
+    const bones = new Map<string, THREE.Bone>()
+    const controller = new BoneController(bones)
+
+    const pose: BodyPose = {
+      head: [1, 1, 1],
+    }
+
+    // Should not throw
+    expect(() => {
+      controller.setPose(pose)
+      controller.update(0.1)
+    }).not.toThrow()
+  })
+
+  it('should only update specified bones in partial pose', () => {
+    const headBone = createMockBone('Head')
+    const spineBone = createMockBone('Spine')
+    const bones = new Map<string, THREE.Bone>([
+      ['Head', headBone],
+      ['Spine', spineBone],
+    ])
+    const controller = new BoneController(bones)
+
+    const pose: BodyPose = {
+      head: [Math.PI / 4, 0, 0],
+    }
+
+    controller.setPose(pose)
+    controller.update(1)
+
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+    expect(spineBone.quaternion.x).toBe(0) // Should remain at zero
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,63 @@
+import * as THREE from 'three'
+import { BodyPose, Vector3 } from '../types'
+
+/**
+ * BoneController — Manages manual skeletal posing for a character.
+ * Maps high-level BodyPose properties to specific Three.js bones and applies
+ * smooth interpolation using slerp.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targetPose: BodyPose = {}
+  private lerpSpeed: number = 5 // Controls the smoothness of pose transitions
+
+  // Scratch variables for optimization to avoid GC pressure in the render loop
+  private static scratchEuler = new THREE.Euler()
+  private static scratchQuaternion = new THREE.Quaternion()
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Sets the target pose for the character.
+   * The controller will smoothly interpolate towards this pose in the update loop.
+   */
+  setPose(pose: BodyPose) {
+    this.targetPose = { ...pose }
+  }
+
+  /**
+   * Updates bone rotations based on the current target pose and delta time.
+   * Should be called within the main animation loop (useFrame).
+   */
+  update(delta: number) {
+    this.applyBoneRotation('head', 'Head', delta)
+    this.applyBoneRotation('spine', 'Spine', delta)
+    this.applyBoneRotation('leftArm', 'LeftArm', delta)
+    this.applyBoneRotation('rightArm', 'RightArm', delta)
+    this.applyBoneRotation('leftLeg', 'LeftUpperLeg', delta)
+    this.applyBoneRotation('rightLeg', 'RightUpperLeg', delta)
+  }
+
+  /**
+   * Interpolates and applies rotation to a specific bone.
+   */
+  private applyBoneRotation(
+    poseKey: keyof BodyPose,
+    boneName: string,
+    delta: number
+  ) {
+    const targetRot = this.targetPose[poseKey] as Vector3 | undefined
+    const bone = this.bones.get(boneName)
+
+    if (!bone || !targetRot) return
+
+    // Convert Euler angles (radians) to Quaternion for stable interpolation
+    BoneController.scratchEuler.set(targetRot[0], targetRot[1], targetRot[2])
+    BoneController.scratchQuaternion.setFromEuler(BoneController.scratchEuler)
+
+    // Smoothly slerp the bone's current quaternion towards the target
+    bone.quaternion.slerp(BoneController.scratchQuaternion, Math.min(1, delta * this.lerpSpeed))
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -8,6 +8,8 @@ export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 
+export { BoneController } from './BoneController'
+
 export { FaceMorphController, BLEND_SHAPES, EXPRESSION_PRESETS, VISEME_MAP } from './FaceMorphController'
 export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -18,6 +18,7 @@ import {
   createWaveClip,
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
+import { BoneController } from '../../character/BoneController'
 import { EyeController } from '../../character/EyeController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
@@ -36,6 +37,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
   // Build character rig
@@ -68,6 +70,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
     faceMorphRef.current = faceMorph
 
+    // Setup bone controller for manual posing
+    const boneController = new BoneController(rig.bones)
+    boneController.setPose(actor.bodyPose || {})
+    boneControllerRef.current = boneController
+
     // Setup eye controller
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
@@ -98,7 +105,14 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.morphTargets])
 
-  // Frame update — animation, face morphs, eye blinks
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current) {
+      boneControllerRef.current.setPose(actor.bodyPose || {})
+    }
+  }, [actor.bodyPose])
+
+  // Frame update — animation, face morphs, bone posing, eye blinks
   useFrame((_state, delta) => {
     // Skeletal animation
     if (animatorRef.current) {
@@ -108,6 +122,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Face morph blending
     if (faceMorphRef.current) {
       faceMorphRef.current.update(delta)
+    }
+
+    // Manual skeletal posing (applied after animation clips)
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Eye auto-blink + look-at


### PR DESCRIPTION
This PR implements the `BoneController` for the `@Animatica/engine` package, as outlined in [Task 12] of the backlog.

### Changes:
- **BoneController.ts**: A new controller that maps `BodyPose` properties (head, spine, arms, legs) to Three.js bones and applies smooth `slerp` interpolation. It uses static scratch variables to avoid memory allocation in the render loop.
- **CharacterRenderer.tsx**: Integrated the `BoneController` into the R3F rendering loop. It now reacts to `actor.bodyPose` changes and applies rotations after the main animation mixer update.
- **index.ts**: Exported the new controller.
- **BoneController.test.ts**: Comprehensive unit tests for rotation application, interpolation, and edge cases.
- **BACKLOG.md**: Updated status for Task 12.

Verified with `pnpm test` in the engine package.

---
*PR created automatically by Jules for task [8516955001966849442](https://jules.google.com/task/8516955001966849442) started by @Fredess74*