### PR TITLE
Bundle Size Audit and Optimization

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-14
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | - | First Load JS |
+| **@Animatica/engine** | 133.4K | +62.4K | Includes index.js (77K) and index.cjs (56K) |
+| **@Animatica/editor** | 177.3K | +101.3K | Includes index.js (107K) and index.cjs (70K) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**318.9K** (excluding web), **420.9K** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (177.3K)
+- `dist/index.js`: 107K
+- `dist/index.cjs`: 70K
+- *Note: Resolved a 3.4MB regression by externalizing three, @react-three/fiber, and @react-three/drei.*
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (133.4K)
+- `dist/index.js`: 77K
+- `dist/index.cjs`: 56K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-14.
+- Fixed major bundle size regression in `@Animatica/editor` by correctly externalizing peer dependencies.
+- `@Animatica/engine` size increased as more features were implemented.
+- `@Animatica/web` First Load JS remains stable at 102K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/engine**: Continue to monitor as R3F components are added.
+- **@Animatica/editor**: Ensure all new heavy dependencies are either essential or externalized if they are peer dependencies.
+- **@Animatica/web**: Monitor First Load JS as more editor features are integrated into the main application.

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
             external: [
                 'react',
                 'react-dom',
+                'three',
+                '@react-three/fiber',
+                '@react-three/drei',
                 '@Animatica/engine',
                 'lucide-react',
                 'clsx',


### PR DESCRIPTION
Performed a bundle size audit across the monorepo. 
- Resolved a 3.4MB bundle size regression in `@Animatica/editor` by externalizing `three`, `@react-three/fiber`, and `@react-three/drei` in `vite.config.ts`.
- Updated `docs/BUNDLE_REPORT.md` with the latest size breakdown for all packages and the web application.
- Verified that `@Animatica/editor` bundle size is now ~177KB (down from >3MB).
- Verified that the changes do not introduce new test regressions.

---
*PR created automatically by Jules for task [16616780462284157503](https://jules.google.com/task/16616780462284157503) started by @Fredess74*