### PR TITLE
perf(bench): add benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { describe, it, afterAll, beforeAll, vi } from 'vitest';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -22,19 +22,30 @@ function measure(name: string, fn: () => void) {
 }
 
 describe('Engine Benchmarks', () => {
+    beforeAll(() => {
+        // Mock localStorage to suppress Zustand persist warnings and optimize throughput
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn(),
+            setItem: vi.fn(),
+            removeItem: vi.fn(),
+            clear: vi.fn(),
+        });
+    });
+
     afterAll(() => {
         const reportDir = path.resolve(__dirname, '../../../../reports');
         if (!fs.existsSync(reportDir)) {
             fs.mkdirSync(reportDir, { recursive: true });
         }
+        // Write results with trailing newline
         fs.writeFileSync(
             path.join(reportDir, 'baseline_metrics.json'),
-            JSON.stringify(results, null, 2)
+            JSON.stringify(results, null, 2) + '\n'
         );
     });
 
     describe('Interpolation Performance', () => {
-        it('Number Interpolation (10k ops, 10k keyframes)', () => {
+        it('Number Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<number>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -44,15 +55,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Number Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Number Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
         });
 
-        it('Vector3 Interpolation (10k ops, 10k keyframes)', () => {
+        it('Vector3 Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<Vector3>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -62,15 +73,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Vector3 Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Vector3 Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
         });
 
-        it('Color Interpolation (10k ops, 10k keyframes)', () => {
+        it('Color Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<string>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -80,10 +91,28 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Color Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Color Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
+                }
+            });
+        });
+
+        it('evaluateTracksAtTime (10k ops, 100 tracks)', () => {
+            const tracks = Array.from({ length: 100 }, (_, i) => ({
+                targetId: `actor-${i}`,
+                property: 'position',
+                keyframes: Array.from({ length: 10 }, (_, j) => ({
+                    time: j * 10,
+                    value: [j, j, j] as Vector3,
+                    easing: 'linear' as const,
+                })),
+            }));
+
+            measure('evaluateTracksAtTime (10k ops, 100 tracks)', () => {
+                for (let i = 0; i < 10000; i++) {
+                    evaluateTracksAtTime(tracks, Math.random() * 100);
                 }
             });
         });
@@ -144,7 +173,7 @@ describe('Engine Benchmarks', () => {
     });
 
     describe('Store Performance', () => {
-        it('Store Update Throughput (10k playback updates)', () => {
+        it('Store Update Throughput (100k playback updates)', () => {
             const { setState, getState } = useSceneStore;
 
             setState({
@@ -160,8 +189,8 @@ describe('Engine Benchmarks', () => {
                 playback: { currentTime: 0, isPlaying: false, frameRate: 24, speed: 1.0, direction: 1, loopMode: 'none' },
             });
 
-            measure('Store Playback Updates (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Store Playback Updates (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     getState().setPlayback({ currentTime: i * 0.1 });
                 }
             });

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,11 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (100k ops)": "4413.44ms",
+  "Vector3 Interpolation (100k ops)": "4665.26ms",
+  "Color Interpolation (100k ops)": "4807.91ms",
+  "evaluateTracksAtTime (10k ops, 100 tracks)": "278.53ms",
+  "Schema Validation Speed (100 runs)": "77.63ms",
+  "Store Playback Updates (100k ops)": "1864.11ms",
+  "Store Add Actor (1k ops)": "265.59ms",
+  "Store Update Actor (1k ops)": "1312.22ms",
+  "Store Remove Actor (1k ops)": "1076.20ms"
 }


### PR DESCRIPTION
Enhanced animation engine benchmarks in `packages/engine/src/__tests__/benchmark.test.ts` to include high-load tests (100k iterations) and `evaluateTracksAtTime` measurement. Recorded updated baseline metrics in `reports/baseline_metrics.json`.

---
*PR created automatically by Jules for task [8327813174949928089](https://jules.google.com/task/8327813174949928089) started by @Fredess74*