### PR TITLE
fix(engine): sync CharacterRenderer tests with implementation

### DIFF
--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
+import * as THREE from 'three'
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,13 +9,25 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
+    useCallback: vi.fn((fn) => fn),
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock @react-three/fiber hooks
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
+
+// Mock CharacterLoader
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: new THREE.Group(),
+    bodyMesh: null,
+    morphTargetMap: {},
+  })),
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +51,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing primitive with correct transform', () => {
+    // Call the functional component directly
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -52,51 +62,33 @@ describe('CharacterRenderer', () => {
     expect(props.position).toEqual([10, 0, 5])
     expect(props.rotation).toEqual([0, Math.PI, 0])
     expect(props.scale).toEqual([1, 1, 1])
+    expect(props.visible).toBe(true)
 
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // First child should be the primitive object (the rig root)
+    const rigPrimitive = children[0] as any
+    expect(rigPrimitive.type).toBe('primitive')
+    expect(rigPrimitive.props.object).toBeDefined()
   })
 
-  it('renders nothing when visible is false', () => {
+  it('sets visible prop correctly', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
+    const result = CharacterRenderer({ actor: invisibleActor }) as React.ReactElement
+    expect((result.props as any).visible).toBe(false)
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection ring when isSelected is true', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Second child should be the selection mesh
+    const selectionMesh = children[1] as any
+    expect(selectionMesh.type).toBe('mesh')
+
+    const meshChildren = React.Children.toArray(selectionMesh.props.children) as React.ReactElement[]
+    expect(meshChildren.some(c => (c as any).type === 'ringGeometry')).toBe(true)
   })
 })


### PR DESCRIPTION
This PR synchronizes the `CharacterRenderer` tests with its current implementation in `@Animatica/engine`. The previous tests were failing because they expected a `forwardRef` component and a specific capsule geometry structure, whereas the actual component is a standard functional component returning a more complex procedural rig.

Key changes:
- Refactored `CharacterRenderer.test.tsx` to mock necessary React and R3F hooks.
- Updated test assertions to match the `group` -> `primitive` hierarchy.
- Verified that selection highlighting (ring mesh) is correctly rendered when `isSelected` is true.
- Ensured type safety in tests by using proper casting for R3F elements.

---
*PR created automatically by Jules for task [6765927839001758557](https://jules.google.com/task/6765927839001758557) started by @Fredess74*