### PR TITLE
chore(legal): license audit

### DIFF
--- a/docs/LICENSE_AUDIT.md
+++ b/docs/LICENSE_AUDIT.md
@@ -1,6 +1,6 @@
 # License Audit
 
-**Date:** 2026-02-25
+**Date:** 2026-04-14
 **Auditor:** Jules (License Auditor)
 
 ## Summary
@@ -27,7 +27,9 @@ Transitive dependencies: 654
 The following dependencies have non-MIT licenses:
 
 | Dependency | Version | License | Type |
-| --- | --- | --- |
+| --- | --- | --- | --- |
+| @csstools/color-helpers | 6.0.2 | MIT-0 | Transitive |
+| @csstools/css-syntax-patches-for-csstree | 1.0.28 | MIT-0 | Transitive |
 | @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 | Transitive |
 | @ethereumjs/rlp | 4.0.1 | MPL-2.0 | Transitive |
 | @ethereumjs/util | 8.1.0 | MPL-2.0 | Transitive |
@@ -45,6 +47,7 @@ The following dependencies have non-MIT licenses:
 | @swc/helpers | 0.5.15 | Apache-2.0 | Transitive |
 | @webgpu/types | 0.1.69 | BSD-3-Clause | Transitive |
 | abbrev | 1.0.9 | ISC | Transitive |
+| amdefine | 1.0.1 | BSD-3-Clause OR MIT | Transitive |
 | ansi-align | 3.0.1 | ISC | Transitive |
 | antlr4ts | 0.5.0-alpha.4 | BSD-3-Clause | Transitive |
 | anymatch | 3.1.3 | ISC | Transitive |
@@ -112,6 +115,7 @@ The following dependencies have non-MIT licenses:
 | semver | 5.7.2 | ISC | Transitive |
 | serialize-javascript | 6.0.2 | BSD-3-Clause | Transitive |
 | setprototypeof | 1.2.0 | ISC | Transitive |
+| sha.js | 2.4.12 | (MIT AND BSD-3-Clause) | Transitive |
 | sha1 | 1.1.1 | BSD-3-Clause | Transitive |
 | sharp | 0.34.5 | Apache-2.0 | Transitive |
 | shelljs | 0.8.5 | BSD-3-Clause | Transitive |
@@ -122,10 +126,12 @@ The following dependencies have non-MIT licenses:
 | source-map-js | 1.2.1 | BSD-3-Clause | Transitive |
 | split2 | 3.2.2 | ISC | Transitive |
 | sprintf-js | 1.0.3 | BSD-3-Clause | Transitive |
+| string-format | 2.0.0 | WTFPL OR MIT | Transitive |
 | table | 6.9.0 | BSD-3-Clause | Transitive |
 | tough-cookie | 6.0.0 | BSD-3-Clause | Transitive |
 | ts-command-line-args | 2.5.1 | ISC | Transitive |
 | tslib | 1.14.1 | 0BSD | Transitive |
+| type-fest | 0.7.1 | (MIT OR CC0-1.0) | Transitive |
 | typescript | 5.9.3 | Apache-2.0 | **Direct** |
 | uglify-js | 3.19.3 | BSD-2-Clause | Transitive |
 | web3-utils | 1.10.4 | LGPL-3.0 | Transitive |
@@ -144,7 +150,7 @@ The following dependencies have non-MIT licenses:
 | --- | --- | --- |
 | @nomicfoundation/hardhat-toolbox | MIT | @Animatica/contracts |
 | @openzeppelin/contracts | MIT | @Animatica/contracts |
-| @react-three/drei | MIT | @Animatica/engine |
+| @react-three/drei | MIT | @Animatica/editor, @Animatica/engine |
 | @react-three/fiber | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
 | @tailwindcss/postcss | MIT | @Animatica/editor |
 | @testing-library/dom | MIT | @Animatica/web |
@@ -152,7 +158,7 @@ The following dependencies have non-MIT licenses:
 | @types/node | MIT | @Animatica/engine |
 | @types/react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
 | @types/react-dom | MIT | @Animatica/editor, @Animatica/platform, @Animatica/web |
-| @types/three | MIT | @Animatica/engine |
+| @types/three | MIT | @Animatica/editor, @Animatica/engine |
 | @types/uuid | MIT | @Animatica/engine |
 | @vitejs/plugin-react | MIT | @Animatica/editor |
 | clsx | MIT | @Animatica/editor |
@@ -172,7 +178,7 @@ The following dependencies have non-MIT licenses:
 | uuid | MIT | @Animatica/engine |
 | vite | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform |
 | vitest | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| zod | MIT | @Animatica/engine |
+| zod | MIT | @Animatica/engine, @Animatica/web |
 | zundo | MIT | @Animatica/engine |
 | zustand | MIT | @Animatica/engine |
 
@@ -867,7 +873,7 @@ The following dependencies have non-MIT licenses:
 | yargs-unparser | 2.0.0 | MIT |
 | yn | 3.1.1 | MIT |
 | yocto-queue | 0.1.0 | MIT |
-| zod | 4.3.6 | MIT |
+| zod | 3.25.76 | MIT |
 | zundo | 2.3.0 | MIT |
 | zustand | 4.5.7 | MIT |
 

--- a/scripts/collect_direct_deps.js
+++ b/scripts/collect_direct_deps.js
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+
+const packagePaths = [
+  'package.json',
+  'packages/contracts/package.json',
+  'packages/platform/package.json',
+  'packages/editor/package.json',
+  'packages/engine/package.json',
+  'apps/web/package.json',
+];
+
+const directDeps = new Set();
+const workspacePackages = new Set();
+
+// First pass to get workspace package names
+for (const p of packagePaths) {
+  const content = JSON.parse(fs.readFileSync(p, 'utf8'));
+  workspacePackages.add(content.name);
+}
+
+// Second pass to collect dependencies
+for (const p of packagePaths) {
+  const content = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const allDeps = {
+    ...content.dependencies,
+    ...content.devDependencies,
+    ...content.peerDependencies,
+  };
+  for (const dep in allDeps) {
+    if (!workspacePackages.has(dep)) {
+      directDeps.add(dep);
+    }
+  }
+}
+
+fs.writeFileSync('direct_deps.json', JSON.stringify(Array.from(directDeps), null, 2));

--- a/scripts/generate_license_report.js
+++ b/scripts/generate_license_report.js
@@ -1,0 +1,140 @@
+import fs from 'fs';
+
+const licensesData = JSON.parse(fs.readFileSync('licenses.json', 'utf8'));
+const directDepsList = JSON.parse(fs.readFileSync('direct_deps.json', 'utf8'));
+const directDepsSet = new Set(directDepsList);
+
+const allDeps = [];
+const flaggedDeps = [];
+const directDepsReport = [];
+
+// pnpm licenses list --json returns an object where keys are license names
+for (const [license, deps] of Object.entries(licensesData)) {
+  for (const dep of deps) {
+    const isDirect = directDepsSet.has(dep.name);
+    const depInfo = {
+      name: dep.name,
+      version: dep.versions[0],
+      license: license,
+      type: isDirect ? 'Direct' : 'Transitive'
+    };
+
+    allDeps.push(depInfo);
+
+    if (license !== 'MIT') {
+      flaggedDeps.push(depInfo);
+    }
+  }
+}
+
+// Sort for consistency
+allDeps.sort((a, b) => a.name.localeCompare(b.name));
+flaggedDeps.sort((a, b) => a.name.localeCompare(b.name));
+
+// Direct dependencies section needs "Used In" information.
+// I'll need to re-scan package.json files for this.
+const packagePaths = [
+  'package.json',
+  'packages/contracts/package.json',
+  'packages/platform/package.json',
+  'packages/editor/package.json',
+  'packages/engine/package.json',
+  'apps/web/package.json',
+];
+
+const directDepsUsage = {};
+
+for (const p of packagePaths) {
+  const content = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const pkgName = content.name === 'Animatica' ? 'Animatica' : content.name;
+  const allPkgDeps = {
+    ...content.dependencies,
+    ...content.devDependencies,
+    ...content.peerDependencies,
+  };
+  for (const dep in allPkgDeps) {
+    if (directDepsSet.has(dep)) {
+      if (!directDepsUsage[dep]) directDepsUsage[dep] = new Set();
+      directDepsUsage[dep].add(pkgName);
+    }
+  }
+}
+
+const directDepsSorted = Array.from(directDepsSet).sort().map(name => {
+    const depData = allDeps.find(d => d.name === name);
+    return {
+        name,
+        license: depData ? depData.license : 'Unknown',
+        usedIn: Array.from(directDepsUsage[name] || []).sort().join(', ')
+    };
+});
+
+const today = new Date().toISOString().split('T')[0];
+
+let markdown = `# License Audit
+
+**Date:** ${today}
+**Auditor:** Jules (License Auditor)
+
+## Summary
+
+This document lists all dependencies used in the project and their licenses. It also flags any non-MIT licenses and checks for the presence of the project's own LICENSE file.
+
+Total dependencies found: ${allDeps.length}
+Direct dependencies: ${directDepsSet.size}
+Transitive dependencies: ${allDeps.length - directDepsSet.size}
+
+## Project License
+
+- **File:** \`LICENSE\`
+- **Status:** Present
+- **License:** MIT
+
+## Source Code Headers
+
+- **Checked:** \`packages/engine/src/index.ts\`
+- **Result:** No license header found.
+
+## Flagged Licenses (Non-MIT)
+
+The following dependencies have non-MIT licenses:
+
+| Dependency | Version | License | Type |
+| --- | --- | --- | --- |
+`;
+
+flaggedDeps.forEach(dep => {
+  markdown += `| ${dep.name} | ${dep.version} | ${dep.license} | ${dep.type === 'Direct' ? '**Direct**' : 'Transitive'} |\n`;
+});
+
+markdown += `
+## Direct Dependencies
+
+| Dependency | License | Used In |
+| --- | --- | --- |
+`;
+
+directDepsSorted.forEach(dep => {
+  markdown += `| ${dep.name} | ${dep.license} | ${dep.usedIn} |\n`;
+});
+
+markdown += `
+## All Dependencies (including transitive)
+
+<details>
+<summary>Click to expand full dependency list</summary>
+
+| Dependency | Version | License |
+| --- | --- | --- |
+`;
+
+allDeps.forEach(dep => {
+  markdown += `| ${dep.name} | ${dep.version} | ${dep.license} |\n`;
+});
+
+markdown += `
+</details>
+`;
+
+fs.writeFileSync('docs/LICENSE_AUDIT.md', markdown);
+console.log('Report generated in docs/LICENSE_AUDIT.md');


### PR DESCRIPTION
This PR performs a comprehensive license audit of the project's dependencies.

Key changes:
- Created `scripts/collect_direct_deps.js` and `scripts/generate_license_report.js` to automate the audit process.
- Generated `docs/LICENSE_AUDIT.md` which includes:
    - Total dependency count (Direct vs Transitive).
    - Status of project LICENSE and source code headers.
    - A table of flagged non-MIT licenses (including Apache-2.0, MPL-2.0, BSD-3-Clause, etc.).
    - A detailed list of direct dependencies and which workspace packages they are used in.
    - A collapsible full list of all 687 dependencies and their versions/licenses.

This audit ensures legal compliance by identifying all non-MIT dependencies physically present in the repository.

---
*PR created automatically by Jules for task [6760180153390499931](https://jules.google.com/task/6760180153390499931) started by @Fredess74*