### PR TITLE
fix(engine): CharacterRenderer visibility and test regression

### DIFF
--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -9,9 +9,16 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: (initial: any) => ({ current: initial || null }),
+    useEffect: () => {},
+    useMemo: (factory: any) => factory(),
   }
 })
+
+// Mock R3F hooks
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
@@ -39,11 +46,11 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group with correct transform', () => {
+    // Call the component as a function to inspect returned JSX
+    // Since it's wrapped in memo, we access the underlying component via .type
+    const Component = (CharacterRenderer as any).type
+    const result = Component({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +63,37 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // First child should be the rig (primitive)
+    const rigPrimitive = children[0]
+    expect(rigPrimitive.type).toBe('primitive')
+    expect((rigPrimitive.props as any).object).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const Component = (CharacterRenderer as any).type
+    const result = Component({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
+  it('renders selection ring only when isSelected is true', () => {
+    const Component = (CharacterRenderer as any).type
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Test with isSelected = true
+    const selectedResult = Component({ actor: mockActor, isSelected: true }) as React.ReactElement<any>
+    const selectedChildren = React.Children.toArray(selectedResult.props.children) as React.ReactElement[]
+
+    // Should have rig + selection ring
+    expect(selectedChildren.length).toBe(2)
+    expect(selectedChildren[1].type).toBe('mesh')
+    expect((selectedChildren[1].props as any).children[0].type).toBe('ringGeometry')
+
+    // Test with isSelected = false
+    const normalResult = Component({ actor: mockActor, isSelected: false }) as React.ReactElement<any>
+    const normalChildren = React.Children.toArray(normalResult.props.children) as React.ReactElement[]
+
+    // Should only have rig
+    expect(normalChildren.length).toBe(1)
+    expect(normalChildren[0].type).toBe('primitive')
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -2,7 +2,7 @@
  * CharacterRenderer — R3F component for rendering a character actor.
  * Creates a procedural humanoid (or loads GLB), applies animation, face morphs, and eye tracking.
  */
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, memo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { createProceduralHumanoid } from '../../character/CharacterLoader'
@@ -28,7 +28,7 @@ interface CharacterRendererProps {
   onClick?: () => void
 }
 
-export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
+export const CharacterRenderer: React.FC<CharacterRendererProps> = memo(({
   actor,
   isSelected = false,
   onClick,
@@ -100,6 +100,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 
   // Frame update — animation, face morphs, eye blinks
   useFrame((_state, delta) => {
+    if (!actor.visible) return
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
@@ -121,6 +122,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   })
 
+  if (!actor.visible) return null
+
   return (
     <group
       ref={groupRef}
@@ -128,7 +131,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       position={actor.transform.position}
       rotation={actor.transform.rotation}
       scale={actor.transform.scale}
-      visible={actor.visible}
       onClick={(e) => {
         e.stopPropagation()
         onClick?.()
@@ -151,4 +153,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       )}
     </group>
   )
-}
+})
+
+CharacterRenderer.displayName = 'CharacterRenderer'


### PR DESCRIPTION
This PR fixes a regression bug in the `CharacterRenderer` component and its corresponding tests within the `@Animatica/engine` package. 

### Changes:
- **CharacterRenderer Component:**
  - Optimized rendering by adding an early return of `null` when `actor.visible` is false.
  - Added a visibility check inside the `useFrame` loop to skip animation logic for invisible actors.
  - Wrapped the component in `React.memo` to reduce unnecessary re-renders.
- **CharacterRenderer Tests:**
  - Fixed a `TypeError` caused by attempting to access `.type.render` on the functional component.
  - Updated test assertions to match the current implementation which uses a procedural humanoid rig (primitive) instead of the outdated placeholder capsule mesh.
  - Added tests to verify the selection ring rendering based on the `isSelected` prop.
  - Enhanced mocks for `react` and `@react-three/fiber` hooks to provide a more stable testing environment.

All 144 tests in `@Animatica/engine` pass after these changes.

---
*PR created automatically by Jules for task [8626956816833298172](https://jules.google.com/task/8626956816833298172) started by @Fredess74*