### PR TITLE
chore(bundle): size audit

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-15
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | 0K | First Load JS (stable) |
+| **@Animatica/engine** | 133K | +62K | Includes index.js (77K) and index.cjs (56K) |
+| **@Animatica/editor** | 3.4M | +3.3M | MAJOR REGRESSION: Three.js/R3F not externalized |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**~3.5M** (excluding web), **~3.6M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4M)
+- `dist/index.js`: 2.1M
+- `dist/index.cjs`: 1.3M
+- *Note: bundling `three`, `@react-three/fiber`, and `@react-three/drei`*
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (133K)
+- `dist/index.js`: 77K
+- `dist/index.cjs`: 56K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-15.
+- `@Animatica/engine` grew by ~62K due to new R3F components and animation logic.
+- **CRITICAL**: `@Animatica/editor` has a bundle size regression (~3.4 MB). Investigation shows `three`, `@react-three/fiber`, and `@react-three/drei` are being bundled instead of being treated as external dependencies.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: IMMEDIATELY update `vite.config.ts` to externalize `three`, `@react-three/fiber`, and `@react-three/drei`.
+- **@Animatica/engine**: Continue monitoring, but current growth is expected given the feature set.
+- **@Animatica/web**: First Load JS remains healthy at 102K.


### PR DESCRIPTION
Updated BUNDLE_REPORT.md with the latest sizes as of 2026-04-15. Identified a 3.4MB regression in @Animatica/editor due to Three.js/R3F not being externalized.

---
*PR created automatically by Jules for task [9504119923794757687](https://jules.google.com/task/9504119923794757687) started by @Fredess74*