### PR TITLE
Implement BoneController for skeletal posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+    boneNames.forEach(name => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+    controller = new BoneController(bones)
+  })
+
+  it('should apply rotation to bones based on BodyPose', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      spine: [0.4, 0.5, 0.6],
+      leftArm: [0.7, 0.8, 0.1],
+      rightArm: [0.1, 0.2, 0.3],
+      leftLeg: [0.4, 0.5, 0.6],
+      rightLeg: [0.7, 0.8, 0.1],
+    }
+
+    controller.update(pose)
+
+    const expectedEulers: Record<string, [number, number, number]> = {
+      'Head': [0.1, 0.2, 0.3],
+      'Spine': [0.4, 0.5, 0.6],
+      'LeftArm': [0.7, 0.8, 0.1],
+      'RightArm': [0.1, 0.2, 0.3],
+      'LeftUpperLeg': [0.4, 0.5, 0.6],
+      'RightUpperLeg': [0.7, 0.8, 0.1],
+    }
+
+    Object.entries(expectedEulers).forEach(([name, rot]) => {
+      const bone = bones.get(name)!
+      // Using a scratch euler with same order to verify
+      const euler = new THREE.Euler().setFromQuaternion(bone.quaternion)
+      expect(euler.x).toBeCloseTo(rot[0])
+      expect(euler.y).toBeCloseTo(rot[1])
+      expect(euler.z).toBeCloseTo(rot[2])
+    })
+  })
+
+  it('should handle partial BodyPose', () => {
+    const pose: BodyPose = {
+      head: [0.5, 0.5, 0.5]
+    }
+
+    controller.update(pose)
+
+    const headBone = bones.get('Head')!
+    const headEuler = new THREE.Euler().setFromQuaternion(headBone.quaternion)
+    expect(headEuler.x).toBeCloseTo(0.5)
+
+    const spineBone = bones.get('Spine')!
+    expect(spineBone.quaternion.x).toBe(0)
+    expect(spineBone.quaternion.y).toBe(0)
+    expect(spineBone.quaternion.z).toBe(0)
+    expect(spineBone.quaternion.w).toBe(1)
+  })
+
+  it('should do nothing if pose is undefined', () => {
+    expect(() => controller.update(undefined as any)).not.toThrow()
+  })
+
+  it('should skip missing bones gracefully', () => {
+    const incompleteBones = new Map<string, THREE.Bone>()
+    const headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    incompleteBones.set('Head', headBone)
+
+    const controllerWithMissingBones = new BoneController(incompleteBones)
+    const pose: BodyPose = {
+      head: [0.1, 0.1, 0.1],
+      spine: [0.2, 0.2, 0.2] // Missing bone
+    }
+
+    expect(() => controllerWithMissingBones.update(pose)).not.toThrow()
+    const headEuler = new THREE.Euler().setFromQuaternion(headBone.quaternion)
+    expect(headEuler.x).toBeCloseTo(0.1)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,49 @@
+import * as THREE from 'three'
+import type { BodyPose } from '../types'
+
+/**
+ * BoneController — Manages skeletal posing by mapping abstract BodyPose properties
+ * to actual Three.js bones.
+ *
+ * Performance Note: Uses static scratch variables to avoid per-frame GC pressure.
+ */
+export class BoneController {
+  private static readonly SCRATCH_EULER = new THREE.Euler()
+
+  private bones: Map<string, THREE.Bone>
+
+  /**
+   * @param bones Map of bone names to THREE.Bone objects (from CharacterRig).
+   */
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Update the skeletal pose based on the provided BodyPose configuration.
+   * This should be called within the useFrame loop after AnimationMixer.update().
+   *
+   * @param pose The body pose to apply.
+   */
+  update(pose: BodyPose): void {
+    if (!pose) return
+
+    if (pose.head) this.applyRotation('Head', pose.head)
+    if (pose.spine) this.applyRotation('Spine', pose.spine)
+    if (pose.leftArm) this.applyRotation('LeftArm', pose.leftArm)
+    if (pose.rightArm) this.applyRotation('RightArm', pose.rightArm)
+    if (pose.leftLeg) this.applyRotation('LeftUpperLeg', pose.leftLeg)
+    if (pose.rightLeg) this.applyRotation('RightUpperLeg', pose.rightLeg)
+  }
+
+  /**
+   * Apply a [x, y, z] rotation to a specific bone.
+   */
+  private applyRotation(boneName: string, rotation: [number, number, number]): void {
+    const bone = this.bones.get(boneName)
+    if (bone) {
+      BoneController.SCRATCH_EULER.set(rotation[0], rotation[1], rotation[2])
+      bone.quaternion.setFromEuler(BoneController.SCRATCH_EULER)
+    }
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -5,6 +5,8 @@
 export { extractRig, createProceduralHumanoid, HUMANOID_BONES } from './CharacterLoader'
 export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 
+export { BoneController } from './BoneController'
+
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -35,6 +36,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 }) => {
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
@@ -63,6 +65,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     animator.registerClip('jump', createJumpClip())
     animator.play(actor.animation || 'idle')
     animatorRef.current = animator
+
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
 
     // Setup face morph controller
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
@@ -103,6 +109,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Custom bone pose (applied after animation)
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.update(actor.bodyPose)
     }
 
     // Face morph blending

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "453.92ms",
+  "Vector3 Interpolation (10k ops)": "547.55ms",
+  "Color Interpolation (10k ops)": "475.93ms",
+  "Schema Validation Speed (100 runs)": "64.43ms",
+  "Store Playback Updates (10k ops)": "195.73ms",
+  "Store Add Actor (1k ops)": "128.46ms",
+  "Store Update Actor (1k ops)": "1297.19ms",
+  "Store Remove Actor (1k ops)": "1061.05ms"
 }


### PR DESCRIPTION
Implemented the `BoneController` class in `@Animatica/engine` to handle procedural skeletal posing. 

Key changes:
- Created `BoneController` to map `BodyPose` (head, spine, arms, legs) to Three.js bones.
- Integrated `BoneController` into `CharacterRenderer` within the `useFrame` loop, ensuring pose overrides are applied after skeletal animations.
- Added unit tests in `BoneController.test.ts` covering success cases, partial poses, and missing bone handling.
- Optimized performance using static scratch variables for Euler rotations to reduce per-frame GC pressure.

---
*PR created automatically by Jules for task [10863738905162461466](https://jules.google.com/task/10863738905162461466) started by @Fredess74*