### PR TITLE
perf(bench): add benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { describe, it, afterAll, vi } from 'vitest';
+
+// Stub localStorage for Zustand persist middleware BEFORE imports that might trigger it
+vi.stubGlobal('localStorage', {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+});
+
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -33,8 +42,8 @@ describe('Engine Benchmarks', () => {
         );
     });
 
-    describe('Interpolation Performance', () => {
-        it('Number Interpolation (10k ops, 10k keyframes)', () => {
+    describe('Interpolation Performance', { timeout: 60000 }, () => {
+        it('Number Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<number>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -44,15 +53,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Number Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Number Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
         });
 
-        it('Vector3 Interpolation (10k ops, 10k keyframes)', () => {
+        it('Vector3 Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<Vector3>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -62,15 +71,15 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Vector3 Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Vector3 Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
         });
 
-        it('Color Interpolation (10k ops, 10k keyframes)', () => {
+        it('Color Interpolation (100k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<string>[] = [];
             for (let i = 0; i < 10000; i++) {
                 keyframes.push({
@@ -80,16 +89,42 @@ describe('Engine Benchmarks', () => {
                 });
             }
 
-            measure('Color Interpolation (10k ops)', () => {
-                for (let i = 0; i < 10000; i++) {
+            measure('Color Interpolation (100k ops)', () => {
+                for (let i = 0; i < 100000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
         });
+
+        it('evaluateTracksAtTime (10k ops, 100 tracks)', () => {
+            const tracks = [];
+            for (let i = 0; i < 100; i++) {
+                const keyframes = [];
+                for (let j = 0; j < 10; j++) {
+                    keyframes.push({
+                        time: j,
+                        value: j * 10,
+                        easing: 'linear' as const,
+                    });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'transform.position.x',
+                    keyframes,
+                });
+            }
+
+            measure('evaluateTracksAtTime (10k ops)', () => {
+                for (let i = 0; i < 10000; i++) {
+                    const t = Math.random() * 10;
+                    evaluateTracksAtTime(tracks, t);
+                }
+            });
+        });
     });
 
-    describe('Schema Validation Performance', () => {
+    describe('Schema Validation Performance', { timeout: 30000 }, () => {
         it('Project Schema Validation (100 runs, 100 actors)', () => {
             const actors: Actor[] = [];
             for (let i = 0; i < 100; i++) {
@@ -143,7 +178,7 @@ describe('Engine Benchmarks', () => {
         });
     });
 
-    describe('Store Performance', () => {
+    describe('Store Performance', { timeout: 30000 }, () => {
         it('Store Update Throughput (10k playback updates)', () => {
             const { setState, getState } = useSceneStore;
 

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,11 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (100k ops)": "4431.53ms",
+  "Vector3 Interpolation (100k ops)": "4625.21ms",
+  "Color Interpolation (100k ops)": "4703.92ms",
+  "evaluateTracksAtTime (10k ops)": "271.48ms",
+  "Schema Validation Speed (100 runs)": "67.13ms",
+  "Store Playback Updates (10k ops)": "197.91ms",
+  "Store Add Actor (1k ops)": "126.30ms",
+  "Store Update Actor (1k ops)": "1299.12ms",
+  "Store Remove Actor (1k ops)": "1041.66ms"
 }


### PR DESCRIPTION
Enhanced animation engine benchmarks and recorded baseline metrics. Added global localStorage stub for store tests, increased interpolation iteration counts, and added evaluateTracksAtTime benchmark.

---
*PR created automatically by Jules for task [10292412115437751119](https://jules.google.com/task/10292412115437751119) started by @Fredess74*