### PR TITLE
Add performance benchmarks for animation engine

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,11 +1,19 @@
-import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { describe, it, afterAll, vi } from 'vitest';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+
+// Stub localStorage for Zustand persist middleware
+vi.stubGlobal('localStorage', {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -84,6 +92,31 @@ describe('Engine Benchmarks', () => {
                 for (let i = 0; i < 10000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
+                }
+            });
+        });
+
+        it('evaluateTracksAtTime (1k tracks, 100 keyframes each)', () => {
+            const tracks = [];
+            for (let i = 0; i < 1000; i++) {
+                const keyframes: Keyframe<number>[] = [];
+                for (let j = 0; j < 100; j++) {
+                    keyframes.push({
+                        time: j,
+                        value: j * 10,
+                        easing: 'linear',
+                    });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'transform.position.x',
+                    keyframes,
+                });
+            }
+
+            measure('evaluateTracksAtTime (100 ops)', () => {
+                for (let i = 0; i < 100; i++) {
+                    evaluateTracksAtTime(tracks, Math.random() * 100);
                 }
             });
         });

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,11 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "446.49ms",
+  "Vector3 Interpolation (10k ops)": "546.34ms",
+  "Color Interpolation (10k ops)": "470.34ms",
+  "evaluateTracksAtTime (100 ops)": "97.70ms",
+  "Schema Validation Speed (100 runs)": "68.04ms",
+  "Store Playback Updates (10k ops)": "173.81ms",
+  "Store Add Actor (1k ops)": "121.45ms",
+  "Store Update Actor (1k ops)": "1241.68ms",
+  "Store Remove Actor (1k ops)": "988.48ms"
 }


### PR DESCRIPTION
Implemented comprehensive performance benchmarks for the Animatica animation engine. 

Key changes:
- Created/Updated `packages/engine/src/__tests__/benchmark.test.ts` with benchmarks for:
    - Interpolation (Number, Vector3, Color)
    - Animation track evaluation (`evaluateTracksAtTime`)
    - Schema validation speed (`ProjectStateSchema`)
    - Store update throughput (Playback updates and Actor CRUD)
- Added `localStorage` stubbing for Zustand persistence compatibility in Vitest.
- Updated `reports/baseline_metrics.json` with the latest performance results.

These benchmarks provide a baseline for future engine optimizations.

---
*PR created automatically by Jules for task [9090149033132213191](https://jules.google.com/task/9090149033132213191) started by @Fredess74*