### PR TITLE
chore(bundle): size audit 2026-04-18

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,33 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-18
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 110K | +8K | First Load JS (Home route) |
+| **@Animatica/engine** | 135.4K | +64.4K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 3.5M | +3.4M | Includes index.js (2.2M) and index.cjs (1.3M) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.6M** (excluding web), **3.7M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.5M)
+- `dist/index.js`: 2,181K
+- `dist/index.cjs`: 1,308K
+- **CRITICAL**: Significant regression detected. Three.js and React-Three-Fiber dependencies are being bundled into the package instead of being externalized.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-18.
+- `@Animatica/engine` size increased following the implementation of Phase 2 features.
+- `@Animatica/editor` size regression identified. The package size has jumped from 76K to 3.5M.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Externalize `three`, `@react-three/fiber`, and `@react-three/drei` in `vite.config.ts`. These should be `peerDependencies` to avoid bundling them in the library output.
+- **@Animatica/web**: 110K First Load JS is excellent. Ensure future editor integrations use the externalized dependencies correctly.

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "531.13ms",
+  "Vector3 Interpolation (10k ops)": "637.99ms",
+  "Color Interpolation (10k ops)": "551.85ms",
+  "Schema Validation Speed (100 runs)": "81.33ms",
+  "Store Playback Updates (10k ops)": "317.45ms",
+  "Store Add Actor (1k ops)": "188.57ms",
+  "Store Update Actor (1k ops)": "1345.18ms",
+  "Store Remove Actor (1k ops)": "1247.42ms"
 }


### PR DESCRIPTION
Performed a full monorepo build and updated the bundle size report in `docs/BUNDLE_REPORT.md`. 

Key findings:
- `@Animatica/web`: 110K First Load JS (Home route)
- `@Animatica/engine`: 135.4K total dist
- `@Animatica/editor`: 3.5M total dist (**CRITICAL REGRESSION**)
- `@Animatica/platform`: 0.2K
- `@Animatica/contracts`: 8K cache

The significant size increase in `@Animatica/editor` (from 76K to 3.5M) is due to Three.js and React-Three-Fiber dependencies being bundled into the package instead of being externalized. I have recommended externalizing these in the report.

Also updated `reports/baseline_metrics.json` with the latest performance metrics from the engine benchmarks.

---
*PR created automatically by Jules for task [10162919164939506558](https://jules.google.com/task/10162919164939506558) started by @Fredess74*