### PR TITLE
feat(engine): implement BoneController for character skeletal posing (#12)

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+    let bones: Map<string, THREE.Bone>
+    let boneController: BoneController
+
+    beforeEach(() => {
+        bones = new Map()
+        // Create dummy bones
+        const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+        boneNames.forEach(name => {
+            const bone = new THREE.Bone()
+            bone.name = name
+            bones.set(name, bone)
+        })
+        boneController = new BoneController(bones)
+    })
+
+    it('should apply rotations to correct bones', () => {
+        const pose: BodyPose = {
+            head: [0.1, 0.2, 0.3],
+            spine: [0.4, 0.5, 0.6],
+            leftArm: [0.7, 0.8, 0.9],
+            rightArm: [1.0, 1.1, 1.2],
+            leftLeg: [1.3, 1.4, 1.5],
+            rightLeg: [1.6, 1.7, 1.8],
+        }
+
+        boneController.update(pose)
+
+        expect(bones.get('Head')?.rotation.x).toBeCloseTo(0.1)
+        expect(bones.get('Spine')?.rotation.y).toBeCloseTo(0.5)
+        expect(bones.get('LeftArm')?.rotation.z).toBeCloseTo(0.9)
+        expect(bones.get('RightArm')?.rotation.x).toBeCloseTo(1.0)
+        expect(bones.get('LeftUpperLeg')?.rotation.y).toBeCloseTo(1.4)
+        expect(bones.get('RightUpperLeg')?.rotation.z).toBeCloseTo(1.8)
+    })
+
+    it('should handle missing bones gracefully', () => {
+        const incompleteBones = new Map<string, THREE.Bone>()
+        const headBone = new THREE.Bone()
+        incompleteBones.set('Head', headBone)
+
+        const controller = new BoneController(incompleteBones)
+
+        const pose: BodyPose = {
+            head: [0.1, 0.1, 0.1],
+            spine: [0.2, 0.2, 0.2], // Missing bone
+        }
+
+        // Should not throw
+        expect(() => controller.update(pose)).not.toThrow()
+        expect(headBone.rotation.x).toBeCloseTo(0.1)
+    })
+
+    it('should handle undefined pose properties', () => {
+        const pose: BodyPose = {
+            head: [0.5, 0.5, 0.5],
+            // spine is undefined
+        }
+
+        const initialSpineRotation = bones.get('Spine')?.rotation.clone()
+
+        boneController.update(pose)
+
+        expect(bones.get('Head')?.rotation.x).toBeCloseTo(0.5)
+        expect(bones.get('Spine')?.rotation.x).toBe(initialSpineRotation?.x)
+    })
+
+    it('should handle null/undefined pose', () => {
+        expect(() => boneController.update(null as any)).not.toThrow()
+        expect(() => boneController.update(undefined as any)).not.toThrow()
+    })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three'
+import { BodyPose } from '../types'
+
+/**
+ * BoneController — Maps a BodyPose object to Three.js bone rotations.
+ *
+ * Maps abstract pose properties to standard humanoid bone names:
+ * - head    -> 'Head'
+ * - spine   -> 'Spine'
+ * - leftArm -> 'LeftArm'
+ * - rightArm-> 'RightArm'
+ * - leftLeg -> 'LeftUpperLeg'
+ * - rightLeg-> 'RightUpperLeg'
+ */
+export class BoneController {
+    private bones: Map<string, THREE.Bone>
+
+    constructor(bones: Map<string, THREE.Bone>) {
+        this.bones = bones
+    }
+
+    /**
+     * Applies the given pose to the character's skeleton.
+     * @param pose The BodyPose object containing rotation overrides.
+     */
+    update(pose: BodyPose): void {
+        if (!pose) return
+
+        this.applyBoneRotation('Head', pose.head)
+        this.applyBoneRotation('Spine', pose.spine)
+        this.applyBoneRotation('LeftArm', pose.leftArm)
+        this.applyBoneRotation('RightArm', pose.rightArm)
+        this.applyBoneRotation('LeftUpperLeg', pose.leftLeg)
+        this.applyBoneRotation('RightUpperLeg', pose.rightLeg)
+    }
+
+    /**
+     * Helper to apply a rotation to a specific bone if it exists.
+     */
+    private applyBoneRotation(boneName: string, rotation?: [number, number, number]): void {
+        if (!rotation) return
+
+        const bone = this.bones.get(boneName)
+        if (bone) {
+            bone.rotation.set(rotation[0], rotation[1], rotation[2])
+        }
+    }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -14,6 +14,8 @@ export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 export { EyeController } from './EyeController'
 export type { EyeState } from './EyeController'
 
+export { BoneController } from './BoneController'
+
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -9,13 +9,40 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: (val: any) => ({ current: val || null }),
+    useEffect: () => {},
+    useMemo: (fn: any) => fn(),
+    useCallback: (fn: any) => fn,
   }
 })
+
+// Mock R3F
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
   Edges: () => null
+}))
+
+// Mock CharacterAnimator
+vi.mock('../../character/CharacterAnimator', () => ({
+  CharacterAnimator: vi.fn().mockImplementation(() => ({
+    registerClip: vi.fn(),
+    play: vi.fn(),
+    update: vi.fn(),
+    setSpeed: vi.fn(),
+    dispose: vi.fn(),
+  })),
+  createIdleClip: vi.fn(),
+  createWalkClip: vi.fn(),
+  createRunClip: vi.fn(),
+  createTalkClip: vi.fn(),
+  createWaveClip: vi.fn(),
+  createDanceClip: vi.fn(),
+  createSitClip: vi.fn(),
+  createJumpClip: vi.fn(),
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +66,10 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group with correct transform', () => {
+    // CharacterRenderer is wrapped in React.memo
+    // When calling directly, use the function itself
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +82,25 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Check for rig root
+    const rigRoot = children.find((c: any) => c.type === 'primitive')
+    expect(rigRoot).toBeDefined()
   })
 
-  it('renders nothing when visible is false', () => {
+  it('sets visibility correctly on the root group', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
+    const result = CharacterRenderer({ actor: invisibleActor }) as React.ReactElement<any>
+    expect(result.props.visible).toBe(false)
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
+  it('renders the rig root using primitive', () => {
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement<any>
+    const props = result.props
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Check for rig root primitive
+    const rigRoot = children.find((c: any) => c.type === 'primitive')
+    expect(rigRoot).toBeDefined()
+    expect((rigRoot as any).props.object).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -72,6 +74,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
 
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
+
     return () => {
       animator.dispose()
     }
@@ -103,6 +109,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Manual bone overrides (BodyPose)
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.update(actor.bodyPose)
     }
 
     // Face morph blending

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "453.89ms",
+  "Vector3 Interpolation (10k ops)": "589.91ms",
+  "Color Interpolation (10k ops)": "533.59ms",
+  "Schema Validation Speed (100 runs)": "92.18ms",
+  "Store Playback Updates (10k ops)": "302.22ms",
+  "Store Add Actor (1k ops)": "142.85ms",
+  "Store Update Actor (1k ops)": "1247.65ms",
+  "Store Remove Actor (1k ops)": "1056.71ms"
 }


### PR DESCRIPTION
Implemented Task 12: Bone Controller. 

Key changes:
- **BoneController.ts**: New class to handle mapping between abstract pose data and the Three.js skeleton.
- **CharacterRenderer.tsx**: Updated to utilize the new BoneController during the frame loop, allowing for manual pose overrides.
- **Tests**: Added new unit tests for the controller and updated/fixed renderer tests to match the current procedural rig architecture.
- **Build**: Verified with a full monorepo build and engine test suite execution.

---
*PR created automatically by Jules for task [3625730968932164155](https://jules.google.com/task/3625730968932164155) started by @Fredess74*