### PR TITLE
Add animation engine benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { describe, it, afterAll, vi } from 'vitest';
+
+// Stub localStorage before importing the store to handle Zustand persistence
+vi.hoisted(() => {
+    vi.stubGlobal('localStorage', {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+    });
+});
+
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -84,6 +95,28 @@ describe('Engine Benchmarks', () => {
                 for (let i = 0; i < 10000; i++) {
                     const t = Math.random() * 10000;
                     interpolateKeyframes(keyframes, t);
+                }
+            });
+        });
+
+        it('evaluateTracksAtTime (1k ops, 100 tracks)', () => {
+            const tracks: any[] = [];
+            for (let i = 0; i < 100; i++) {
+                const keyframes: any[] = [];
+                for (let j = 0; j < 10; j++) {
+                    keyframes.push({ time: j, value: j * 10 });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'position.x',
+                    keyframes
+                });
+            }
+
+            measure('evaluateTracksAtTime (1k ops)', () => {
+                for (let i = 0; i < 1000; i++) {
+                    const t = Math.random() * 10;
+                    evaluateTracksAtTime(tracks, t);
                 }
             });
         });

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,11 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "425.31ms",
+  "Vector3 Interpolation (10k ops)": "508.68ms",
+  "Color Interpolation (10k ops)": "461.85ms",
+  "evaluateTracksAtTime (1k ops)": "42.98ms",
+  "Schema Validation Speed (100 runs)": "60.31ms",
+  "Store Playback Updates (10k ops)": "185.67ms",
+  "Store Add Actor (1k ops)": "119.99ms",
+  "Store Update Actor (1k ops)": "1234.99ms",
+  "Store Remove Actor (1k ops)": "942.00ms"
 }


### PR DESCRIPTION
Implemented benchmarks for interpolation speed, schema validation, and store update throughput. Recorded results in reports/baseline_metrics.json. Added a localStorage stub in benchmarks to handle Zustand persistence.

---
*PR created automatically by Jules for task [10989895376675604022](https://jules.google.com/task/10989895376675604022) started by @Fredess74*