### PR TITLE
feat(engine): implement BoneController (#12)

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+    boneNames.forEach((name) => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+    controller = new BoneController(bones)
+  })
+
+  it('should initialize with identity rotations', () => {
+    bones.forEach((bone) => {
+      expect(bone.quaternion.x).toBe(0)
+      expect(bone.quaternion.y).toBe(0)
+      expect(bone.quaternion.z).toBe(0)
+      expect(bone.quaternion.w).toBe(1)
+    })
+  })
+
+  it('should snap to pose immediately', () => {
+    const pose: BodyPose = {
+      head: [Math.PI / 4, 0, 0],
+      leftArm: [0, 0, Math.PI / 2],
+    }
+
+    controller.snapToPose(pose)
+
+    const headBone = bones.get('Head')!
+    const leftArmBone = bones.get('LeftArm')!
+
+    const expectedHeadQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 4, 0, 0))
+    const expectedArmQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, Math.PI / 2))
+
+    expect(headBone.quaternion.x).toBeCloseTo(expectedHeadQuat.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expectedHeadQuat.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expectedHeadQuat.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expectedHeadQuat.w)
+
+    expect(leftArmBone.quaternion.x).toBeCloseTo(expectedArmQuat.x)
+    expect(leftArmBone.quaternion.y).toBeCloseTo(expectedArmQuat.y)
+    expect(leftArmBone.quaternion.z).toBeCloseTo(expectedArmQuat.z)
+    expect(leftArmBone.quaternion.w).toBeCloseTo(expectedArmQuat.w)
+  })
+
+  it('should smoothly interpolate to pose over multiple updates', () => {
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+
+    controller.setPose(pose)
+
+    // First update (16ms)
+    controller.update(0.016)
+
+    const headBone = bones.get('Head')!
+    // Should have moved from identity but not reached target yet
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+    expect(headBone.quaternion.x).toBeLessThan(0.707) // sin(PI/4)
+
+    // Many updates later
+    for (let i = 0; i < 60; i++) {
+      controller.update(0.016)
+    }
+
+    const finalQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0))
+    expect(headBone.quaternion.x).toBeCloseTo(finalQuat.x, 2)
+  })
+
+  it('should reset all bones to identity', () => {
+    const pose: BodyPose = {
+      head: [1, 1, 1],
+      spine: [1, 1, 1],
+    }
+
+    controller.snapToPose(pose)
+    controller.reset()
+
+    bones.forEach((bone) => {
+      expect(bone.quaternion.x).toBe(0)
+      expect(bone.quaternion.y).toBe(0)
+      expect(bone.quaternion.z).toBe(0)
+      expect(bone.quaternion.w).toBe(1)
+    })
+  })
+
+  it('should handle missing bones gracefully', () => {
+    const incompleteBones = new Map<string, THREE.Bone>()
+    incompleteBones.set('Head', new THREE.Bone())
+    const partialController = new BoneController(incompleteBones)
+
+    const pose: BodyPose = {
+      head: [1, 0, 0],
+      spine: [1, 0, 0], // missing bone
+    }
+
+    expect(() => partialController.snapToPose(pose)).not.toThrow()
+    expect(incompleteBones.get('Head')!.quaternion.x).toBeGreaterThan(0)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,115 @@
+import * as THREE from 'three'
+import type { BodyPose } from '../types'
+
+/**
+ * Maps BodyPose properties to standard humanoid bone names.
+ */
+const BONE_MAP: Record<keyof BodyPose, string> = {
+  head: 'Head',
+  spine: 'Spine',
+  leftArm: 'LeftArm',
+  rightArm: 'RightArm',
+  leftLeg: 'LeftUpperLeg',
+  rightLeg: 'RightUpperLeg',
+}
+
+/**
+ * BoneController — Manages skeletal posing by mapping BodyPose to bone rotations.
+ * Supports smooth interpolation (slerp) between poses.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targetQuaternions: Map<string, THREE.Quaternion> = new Map()
+  private currentQuaternions: Map<string, THREE.Quaternion> = new Map()
+  private lerpSpeed: number = 10.0 // higher is faster
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+
+    // Initialize current quaternions from existing bone rotations
+    for (const key of Object.keys(BONE_MAP) as Array<keyof BodyPose>) {
+      const boneName = BONE_MAP[key]
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        this.currentQuaternions.set(key, bone.quaternion.clone())
+        this.targetQuaternions.set(key, bone.quaternion.clone())
+      }
+    }
+  }
+
+  /**
+   * Sets the target pose for the character.
+   * Rotations in BodyPose are expected to be Euler angles in radians [x, y, z].
+   */
+  setPose(pose: BodyPose): void {
+    for (const [key, rotation] of Object.entries(pose)) {
+      if (!rotation) continue
+
+      const boneName = BONE_MAP[key as keyof BodyPose]
+      if (!boneName || !this.bones.has(boneName)) continue
+
+      const targetQuat = new THREE.Quaternion().setFromEuler(
+        new THREE.Euler(rotation[0], rotation[1], rotation[2])
+      )
+      this.targetQuaternions.set(key, targetQuat)
+    }
+  }
+
+  /**
+   * Update bone rotations with smooth interpolation.
+   * Call this every frame.
+   */
+  update(delta: number): void {
+    const step = this.lerpSpeed * delta
+
+    for (const [key, target] of this.targetQuaternions.entries()) {
+      const boneName = BONE_MAP[key as keyof BodyPose]
+      const bone = this.bones.get(boneName)
+      const current = this.currentQuaternions.get(key)
+
+      if (!bone || !current) continue
+
+      // Slerp current towards target
+      current.slerp(target, Math.min(step, 1.0))
+
+      // Apply to bone
+      bone.quaternion.copy(current)
+    }
+  }
+
+  /**
+   * Immediately snap to the target pose without interpolation.
+   */
+  snapToPose(pose: BodyPose): void {
+    this.setPose(pose)
+    for (const [key, target] of this.targetQuaternions.entries()) {
+      const boneName = BONE_MAP[key as keyof BodyPose]
+      const bone = this.bones.get(boneName)
+      const current = this.currentQuaternions.get(key)
+
+      if (bone && current) {
+        current.copy(target)
+        bone.quaternion.copy(target)
+      }
+    }
+  }
+
+  /**
+   * Reset all controlled bones to their default (identity) rotation.
+   */
+  reset(): void {
+    const identity = new THREE.Quaternion()
+    for (const key of Object.keys(BONE_MAP) as Array<keyof BodyPose>) {
+      const boneName = BONE_MAP[key]
+      const bone = this.bones.get(boneName)
+      const current = this.currentQuaternions.get(key)
+      const target = this.targetQuaternions.get(key)
+
+      if (bone && current && target) {
+        current.copy(identity)
+        target.copy(identity)
+        bone.quaternion.copy(identity)
+      }
+    }
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -5,6 +5,8 @@
 export { extractRig, createProceduralHumanoid, HUMANOID_BONES } from './CharacterLoader'
 export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 
+export { BoneController } from './BoneController'
+
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -9,9 +9,18 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
+    useCallback: vi.fn((fn) => fn),
+    memo: (c: any) => c,
   }
 })
+
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
@@ -39,11 +48,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
+  it('renders a group with correct transform', () => {
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -52,51 +59,24 @@ describe('CharacterRenderer', () => {
     expect(props.position).toEqual([10, 0, 5])
     expect(props.rotation).toEqual([0, Math.PI, 0])
     expect(props.scale).toEqual([1, 1, 1])
-
-    // Verify children
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders the rig root via primitive', () => {
+    // @ts-ignore
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // First child should be the primitive object={rig.root}
+    const rigPrimitive = children[0] as React.ReactElement
+    expect(rigPrimitive.type).toBe('primitive')
+    expect(rigPrimitive.props.object).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -2,10 +2,11 @@
  * CharacterRenderer — R3F component for rendering a character actor.
  * Creates a procedural humanoid (or loads GLB), applies animation, face morphs, and eye tracking.
  */
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, memo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { createProceduralHumanoid } from '../../character/CharacterLoader'
+import { BoneController } from '../../character/BoneController'
 import {
   CharacterAnimator,
   createDanceClip,
@@ -28,13 +29,14 @@ interface CharacterRendererProps {
   onClick?: () => void
 }
 
-export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
+export const CharacterRenderer: React.FC<CharacterRendererProps> = memo(({
   actor,
   isSelected = false,
   onClick,
 }) => {
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
@@ -48,7 +50,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     return createProceduralHumanoid({ skinColor, height, build })
   }, [actor.name])
 
-  // Setup animator
+  // Setup controllers and animator
   useEffect(() => {
     if (!rig.root) return
 
@@ -63,6 +65,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     animator.registerClip('jump', createJumpClip())
     animator.play(actor.animation || 'idle')
     animatorRef.current = animator
+
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    if (actor.bodyPose) {
+      boneController.snapToPose(actor.bodyPose)
+    }
+    boneControllerRef.current = boneController
 
     // Setup face morph controller
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
@@ -91,18 +100,30 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.animationSpeed])
 
-  // React to morph target / expression changes from CharacterPanel
+  // React to morph target / expression changes
   useEffect(() => {
     if (faceMorphRef.current && actor.morphTargets) {
       faceMorphRef.current.setTarget(actor.morphTargets as any)
     }
   }, [actor.morphTargets])
 
-  // Frame update — animation, face morphs, eye blinks
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setPose(actor.bodyPose)
+    }
+  }, [actor.bodyPose])
+
+  // Frame update — animation, bone posing, face morphs, eye blinks
   useFrame((_state, delta) => {
-    // Skeletal animation
+    // Skeletal animation (from clips)
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Procedural bone posing (overrides/adds to animation)
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending
@@ -120,6 +141,9 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       faceMorphRef.current.setImmediate(eyeValues)
     }
   })
+
+  // Visibility check MUST be after all hook declarations to comply with Rules of Hooks
+  if (!actor.visible) return null
 
   return (
     <group
@@ -151,4 +175,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       )}
     </group>
   )
-}
+})
+
+CharacterRenderer.displayName = 'CharacterRenderer'


### PR DESCRIPTION
Implemented the BoneController for humanoid characters to allow procedural bone posing via the bodyPose object. Integrated the controller into CharacterRenderer.tsx with smooth interpolation and layered it on top of clip-based animations. Fixed a Rule of Hooks violation in CharacterRenderer and updated tests to verify the new functionality.

---
*PR created automatically by Jules for task [10450428901185752154](https://jules.google.com/task/10450428901185752154) started by @Fredess74*