### PR TITLE
Nightly Status Report 2026-04-22

### DIFF
--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "461.85ms",
+  "Vector3 Interpolation (10k ops)": "554.17ms",
+  "Color Interpolation (10k ops)": "495.84ms",
+  "Schema Validation Speed (100 runs)": "84.78ms",
+  "Store Playback Updates (10k ops)": "297.89ms",
+  "Store Add Actor (1k ops)": "132.75ms",
+  "Store Update Actor (1k ops)": "1269.54ms",
+  "Store Remove Actor (1k ops)": "1006.63ms"
 }

--- a/reports/daily/2026-04-22.md
+++ b/reports/daily/2026-04-22.md
@@ -1,0 +1,36 @@
+# Animatica Nightly Status Report - 2026-04-22
+
+## Project Overview
+- **Project Health Score:** 6/10
+- **Status:** Phase 2 (Characters) & Phase 3 (Editor UI) active. Project stagnant since March 2026.
+
+## Quality Metrics
+- **Tests Passing:** 172
+- **Tests Failing:** 7
+- **Total Tests:** 179
+*Note: Failures located in `packages/engine/src/scene/renderers/CharacterRenderer.test.tsx` (3) and `packages/editor/src/viewport/Viewport.test.tsx` (4).*
+
+## Issue Tracking
+- **Open Issues:** 34 (as tracked in BACKLOG.md)
+- **Closed Issues Today:** 0
+- **Total Closed Issues:** 17 (as tracked in AGENT_COMPLETED.md)
+
+## Activity Summary (Today)
+- **Commits Today:** 0
+- **Files Changed Today:** 0 (Report generation only)
+
+## Key Accomplishments
+- **Environment Stabilization:** Successfully ran `pnpm install` and verified build/test pipeline from the monorepo root.
+- **Audit Completion:** Performed a comprehensive audit of all documentation in `docs/`, including AI Pipeline, Smart Contracts, and Data Models.
+- **Metrics Verification:** Extracted current test coverage and issue counts to provide an accurate baseline for upcoming tasks.
+
+## Blockers Found
+- **Regression in CharacterRenderer:** `CharacterRenderer.test.tsx` is failing with `TypeError: Cannot read properties of undefined (reading 'render')`, likely due to a mismatch between the component implementation and the test's expectation of a `forwardRef`.
+- **Documentation Stagnation:** `BACKLOG.md` and `PROGRESS.md` are out of sync with the actual implementation status of several Phase 1 components.
+- **Legacy Blockchain Residue:** `packages/contracts` and `docs/SMART_CONTRACTS.md` remain in the codebase despite being marked as off-scope in `JULES_GUIDE.md`.
+
+## Recommendations for Tomorrow
+1. **Fix CharacterRenderer Regression:** Update the component or test to resolve the `TypeError` and restore a clean test pass.
+2. **Backlog Cleanup:** Sync `BACKLOG.md` with the current state of the engine. Specifically, verify the completion of Tasks 7-10.
+3. **Architecture Cleanup:** Delete `packages/contracts/` and `docs/SMART_CONTRACTS.md` as instructed by the Conductor to align with the non-blockchain vision.
+4. **Resume Feature Development:** Continue with Task 11 (`Humanoid` renderer) to advance Phase 2.


### PR DESCRIPTION
Generated the nightly status report for 2026-04-22. The report includes project health metrics, test results, issue tracking status, and recommendations for the next development cycle. Findings indicate several test regressions in the engine and editor packages and project stagnation since March 2026.

---
*PR created automatically by Jules for task [2816543237337406529](https://jules.google.com/task/2816543237337406529) started by @Fredess74*