### PR TITLE
Add Animation Engine Benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
+import * as Easing from '../animation/easing';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -87,6 +88,58 @@ describe('Engine Benchmarks', () => {
                 }
             });
         });
+
+        it('Unsorted Keyframes Overhead (1k ops, 1k keyframes)', () => {
+            const keyframes: Keyframe<number>[] = [];
+            for (let i = 0; i < 1000; i++) {
+                keyframes.push({
+                    time: Math.random() * 1000,
+                    value: i,
+                    easing: 'linear',
+                });
+            }
+
+            measure('Unsorted Keyframes Overhead (1k ops)', () => {
+                for (let i = 0; i < 1000; i++) {
+                    const t = Math.random() * 1000;
+                    interpolateKeyframes(keyframes, t);
+                }
+            });
+        });
+
+        it('Evaluate Tracks (1k tracks, 10 keyframes each)', () => {
+            const tracks = [];
+            for (let i = 0; i < 1000; i++) {
+                const keyframes: Keyframe<number>[] = [];
+                for (let j = 0; j < 10; j++) {
+                    keyframes.push({ time: j, value: j, easing: 'linear' });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'position.x',
+                    keyframes,
+                });
+            }
+
+            measure('Evaluate Tracks (1k tracks)', () => {
+                for (let i = 0; i < 100; i++) {
+                    evaluateTracksAtTime(tracks, Math.random() * 10);
+                }
+            });
+        });
+    });
+
+    describe('Easing Functions Performance', () => {
+        it('Easing Functions (1M ops)', () => {
+            const functions = Object.values(Easing).filter(f => typeof f === 'function');
+            measure('Easing Functions (1M ops)', () => {
+                for (let i = 0; i < 1000000; i++) {
+                    const t = Math.random();
+                    const fn = functions[i % functions.length];
+                    fn(t);
+                }
+            });
+        });
     });
 
     describe('Schema Validation Performance', () => {
@@ -141,6 +194,58 @@ describe('Engine Benchmarks', () => {
                 }
             });
         });
+
+        it('Large Project Schema Validation (10 runs, 1000 actors)', () => {
+            const actors: Actor[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const actor: PrimitiveActor = {
+                    id: `actor-${i}`,
+                    name: `Actor ${i}`,
+                    type: 'primitive',
+                    transform: {
+                        position: [Math.random() * 10, 0, 0],
+                        rotation: [0, 0, 0],
+                        scale: [1, 1, 1],
+                    },
+                    visible: true,
+                    properties: {
+                        shape: 'box',
+                        color: '#ff0000',
+                        roughness: 0.5,
+                        metalness: 0.5,
+                        opacity: 1,
+                        wireframe: false,
+                    },
+                };
+                actors.push(actor);
+            }
+
+            const projectState: ProjectState = {
+                meta: {
+                    title: 'Large Benchmark Project',
+                    version: '1.0.0',
+                },
+                environment: {
+                    ambientLight: { intensity: 0.5, color: '#ffffff' },
+                    sun: { position: [10, 10, 10], intensity: 1, color: '#ffffff' },
+                    skyColor: '#87CEEB',
+                },
+                actors,
+                timeline: {
+                    duration: 60,
+                    cameraTrack: [],
+                    animationTracks: [],
+                    markers: [],
+                },
+                library: { clips: [] },
+            };
+
+            measure('Large Project Validation (10 runs)', () => {
+                for (let i = 0; i < 10; i++) {
+                    ProjectStateSchema.parse(projectState);
+                }
+            });
+        });
     });
 
     describe('Store Performance', () => {
@@ -167,7 +272,7 @@ describe('Engine Benchmarks', () => {
             });
         });
 
-        it('Store Actor CRUD Throughput (1k actors)', () => {
+        it('Store Actor CRUD Throughput (1k actors)', { timeout: 15000 }, () => {
             const { setState, getState } = useSceneStore;
 
             setState({

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,13 +8,44 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
+    useCallback: vi.fn((fn) => fn),
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock @react-three/fiber hooks
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+  useThree: vi.fn(() => ({})),
+}))
+
+// Mock internal utilities to return stable values
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: { name: 'root' },
+    bodyMesh: {},
+    morphTargetMap: {}
+  }))
+}))
+
+vi.mock('../../character/CharacterAnimator', () => ({
+  CharacterAnimator: vi.fn().mockImplementation(() => ({
+    registerClip: vi.fn(),
+    play: vi.fn(),
+    update: vi.fn(),
+    dispose: vi.fn(),
+    setSpeed: vi.fn()
+  })),
+  createIdleClip: vi.fn(),
+  createWalkClip: vi.fn(),
+  createRunClip: vi.fn(),
+  createTalkClip: vi.fn(),
+  createWaveClip: vi.fn(),
+  createDanceClip: vi.fn(),
+  createSitClip: vi.fn(),
+  createJumpClip: vi.fn(),
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +69,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing primitive rig with correct transform', () => {
+    // Call the component function directly
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +84,16 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Rig child (primitive)
+    const rigChild = children[0] as React.ReactElement
+    expect(rigChild.type).toBe('primitive')
+    expect(rigChild.props.object).toEqual({ name: 'root' })
   })
 
-  it('renders nothing when visible is false', () => {
+  it('still renders group when visible is false (visibility is handled by group prop)', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
-  })
-
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    const result = CharacterRenderer({ actor: invisibleActor }) as React.ReactElement
+    expect(result).not.toBeNull()
+    expect(result.props.visible).toBe(false)
   })
 })

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,14 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "535.59ms",
+  "Vector3 Interpolation (10k ops)": "633.40ms",
+  "Color Interpolation (10k ops)": "529.25ms",
+  "Unsorted Keyframes Overhead (1k ops)": "395.78ms",
+  "Evaluate Tracks (1k tracks)": "49.91ms",
+  "Easing Functions (1M ops)": "63.25ms",
+  "Schema Validation Speed (100 runs)": "99.29ms",
+  "Large Project Validation (10 runs)": "45.23ms",
+  "Store Playback Updates (10k ops)": "362.85ms",
+  "Store Add Actor (1k ops)": "157.75ms",
+  "Store Update Actor (1k ops)": "1534.50ms",
+  "Store Remove Actor (1k ops)": "1250.93ms"
 }


### PR DESCRIPTION
Enhanced animation engine benchmarks and recorded baseline metrics.

- Added benchmark for `evaluateTracksAtTime` to measure multi-track evaluation performance.
- Added benchmark for unsorted keyframes to measure sorting overhead.
- Added benchmark for easing functions (1M operations).
- Added benchmark for large project schema validation (1k actors).
- Updated `reports/baseline_metrics.json` with new baseline data.
- Fixed `CharacterRenderer.test.tsx` to align with the functional component implementation.

---
*PR created automatically by Jules for task [17798540161342638752](https://jules.google.com/task/17798540161342638752) started by @Fredess74*