### PR TITLE
feat(engine): implement BoneController for character posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+
+    boneNames.forEach(name => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+
+    controller = new BoneController(bones)
+    // Fast lerp for testing final values
+    controller.setLerpSpeed(1000)
+  })
+
+  it('should apply rotations to correct bones', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      spine: [0.4, 0.5, 0.6],
+      leftArm: [0.7, 0.8, 0.9],
+    }
+
+    controller.setTargetPose(pose)
+    controller.update(0.1)
+
+    const head = bones.get('Head')!
+    const headEuler = new THREE.Euler().setFromQuaternion(head.quaternion)
+    expect(headEuler.x).toBeCloseTo(0.1)
+    expect(headEuler.y).toBeCloseTo(0.2)
+    expect(headEuler.z).toBeCloseTo(0.3)
+
+    const spine = bones.get('Spine')!
+    const spineEuler = new THREE.Euler().setFromQuaternion(spine.quaternion)
+    expect(spineEuler.x).toBeCloseTo(0.4)
+    expect(spineEuler.y).toBeCloseTo(0.5)
+    expect(spineEuler.z).toBeCloseTo(0.6)
+  })
+
+  it('should interpolate rotations smoothly', () => {
+    controller.setLerpSpeed(1.0)
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+
+    controller.setTargetPose(pose)
+
+    // Halfway step
+    controller.update(0.5)
+
+    const head = bones.get('Head')!
+    // Since we use slerp with step = delta * lerpSpeed = 0.5 * 1.0 = 0.5
+    // It should be roughly halfway between identity and target
+    expect(head.quaternion.x).toBeGreaterThan(0)
+    expect(head.quaternion.x).toBeLessThan(new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI/2, 0, 0)).x)
+  })
+
+  it('should reset to identity if pose property is missing', () => {
+    // Start with a rotation
+    const head = bones.get('Head')!
+    head.quaternion.setFromEuler(new THREE.Euler(1, 1, 1))
+
+    // Set empty pose
+    controller.setTargetPose({})
+    controller.update(1.0) // complete step
+
+    expect(head.quaternion.x).toBeCloseTo(0)
+    expect(head.quaternion.y).toBeCloseTo(0)
+    expect(head.quaternion.z).toBeCloseTo(0)
+    expect(head.quaternion.w).toBeCloseTo(1)
+  })
+
+  it('should handle missing bones gracefully', () => {
+    const incompleteBones = new Map<string, THREE.Bone>()
+    const partialController = new BoneController(incompleteBones)
+
+    expect(() => {
+      partialController.setTargetPose({ head: [1, 1, 1] })
+      partialController.update(0.1)
+    }).not.toThrow()
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,76 @@
+/**
+ * BoneController — Maps abstract BodyPose data to character skeleton bones.
+ * Supports smooth interpolation (slerp) between poses.
+ */
+import * as THREE from 'three'
+import { BodyPose, Vector3 } from '../types'
+
+/**
+ * Controller for applying custom rotations to character bones.
+ * Used for manual posing on top of or instead of animations.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targetPose: BodyPose = {}
+  private lerpSpeed: number = 8.0 // Speed of interpolation (higher = faster)
+
+  /**
+   * @param bones Map of bone names to THREE.Bone instances.
+   */
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Set a new target pose for the character.
+   * @param pose The desired body pose rotations.
+   */
+  setTargetPose(pose: BodyPose): void {
+    this.targetPose = { ...pose }
+  }
+
+  /**
+   * Update bone rotations. Call this every frame.
+   * @param delta Time since last frame in seconds.
+   */
+  update(delta: number): void {
+    const step = Math.min(delta * this.lerpSpeed, 1.0)
+
+    // Map BodyPose fields to standard humanoid bones
+    this.applyRotation('head', 'Head', step)
+    this.applyRotation('spine', 'Spine', step)
+    this.applyRotation('leftArm', 'LeftArm', step)
+    this.applyRotation('rightArm', 'RightArm', step)
+    this.applyRotation('leftLeg', 'LeftUpperLeg', step)
+    this.applyRotation('rightLeg', 'RightUpperLeg', step)
+  }
+
+  /**
+   * Internal helper to apply slerp rotation to a specific bone.
+   */
+  private applyRotation(poseKey: keyof BodyPose, boneName: string, step: number): void {
+    const rotation = this.targetPose[poseKey] as Vector3 | undefined
+    const bone = this.bones.get(boneName)
+
+    if (!bone) return
+
+    // Create target quaternion from Euler angles (radians)
+    const targetQuat = new THREE.Quaternion()
+    if (rotation) {
+      targetQuat.setFromEuler(new THREE.Euler(rotation[0], rotation[1], rotation[2]))
+    } else {
+      // Default to identity rotation (neutral pose)
+      targetQuat.set(0, 0, 0, 1)
+    }
+
+    // Smoothly interpolate to the target
+    bone.quaternion.slerp(targetQuat, step)
+  }
+
+  /**
+   * Set the interpolation speed.
+   */
+  setLerpSpeed(speed: number): void {
+    this.lerpSpeed = speed
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -5,6 +5,8 @@
 export { extractRig, createProceduralHumanoid, HUMANOID_BONES } from './CharacterLoader'
 export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 
+export { BoneController } from './BoneController'
+
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,28 +1,83 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
+import * as THREE from 'three'
 
-// Mock react to bypass hooks checks when calling component directly
+// Mock react hooks
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
+    useCallback: vi.fn((fn) => fn),
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock R3F hooks
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+  useThree: vi.fn(() => ({})),
+}))
+
+// Mock Character utilities
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: new THREE.Group(),
+    bodyMesh: null,
+    skeleton: null,
+    bones: new Map(),
+    morphTargetMap: {},
+    animations: [],
+  })),
+}))
+
+vi.mock('../../character/CharacterAnimator', () => ({
+  CharacterAnimator: vi.fn().mockImplementation(() => ({
+    registerClip: vi.fn(),
+    play: vi.fn(),
+    update: vi.fn(),
+    setSpeed: vi.fn(),
+    dispose: vi.fn(),
+  })),
+  createIdleClip: vi.fn(),
+  createWalkClip: vi.fn(),
+  createRunClip: vi.fn(),
+  createTalkClip: vi.fn(),
+  createWaveClip: vi.fn(),
+  createDanceClip: vi.fn(),
+  createSitClip: vi.fn(),
+  createJumpClip: vi.fn(),
+}))
+
+vi.mock('../../character/FaceMorphController', () => ({
+  FaceMorphController: vi.fn().mockImplementation(() => ({
+    setTarget: vi.fn(),
+    update: vi.fn(),
+    setImmediate: vi.fn(),
+  })),
+}))
+
+vi.mock('../../character/EyeController', () => ({
+  EyeController: vi.fn().mockImplementation(() => ({
+    update: vi.fn(() => ({})),
+  })),
+}))
+
+vi.mock('../../character/BoneController', () => ({
+  BoneController: vi.fn().mockImplementation(() => ({
+    setTargetPose: vi.fn(),
+    update: vi.fn(),
+  })),
+}))
+
+vi.mock('../../character/CharacterPresets', () => ({
+  getPreset: vi.fn(() => null),
 }))
 
 describe('CharacterRenderer', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   const mockActor: CharacterActor = {
     id: 'char-1',
     name: 'Hero',
@@ -31,72 +86,47 @@ describe('CharacterRenderer', () => {
     transform: {
       position: [10, 0, 5],
       rotation: [0, Math.PI, 0],
-      scale: [1, 1, 1]
+      scale: [1, 1, 1],
     },
     animation: 'idle',
     morphTargets: {},
     bodyPose: {},
-    clothing: {}
+    clothing: {},
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Directly mock useRef on the React object
+    vi.spyOn(React, 'useRef').mockReturnValue({ current: null })
+  })
+
+  it('renders a group containing the character rig', () => {
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
-
     const props = result.props as any
     expect(props.position).toEqual([10, 0, 5])
     expect(props.rotation).toEqual([0, Math.PI, 0])
     expect(props.scale).toEqual([1, 1, 1])
 
-    // Verify children
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    const children = React.Children.toArray(props.children)
+    const primitive = children.find((child: any) => child.type === 'primitive')
+    expect(primitive).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
+    const result = CharacterRenderer({ actor: invisibleActor }) as React.ReactElement
+    const props = result.props as any
+    expect(props.visible).toBe(false)
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection ring when selected', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    const children = React.Children.toArray(props.children)
+    const ring = children.find((child: any) => child.type === 'mesh')
+    expect(ring).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../character/CharacterAnimator'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
+import { BoneController } from '../../character/BoneController'
 import { getPreset } from '../../character/CharacterPresets'
 import type { CharacterActor } from '../../types'
 
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -72,6 +74,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
 
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    if (actor.bodyPose) {
+      boneController.setTargetPose(actor.bodyPose)
+    }
+    boneControllerRef.current = boneController
+
     return () => {
       animator.dispose()
     }
@@ -98,11 +107,23 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.morphTargets])
 
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setTargetPose(actor.bodyPose)
+    }
+  }, [actor.bodyPose])
+
   // Frame update — animation, face morphs, eye blinks
   useFrame((_state, delta) => {
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Custom body posing (applied on top of animation)
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending


### PR DESCRIPTION
Implemented the BoneController to allow manual character posing by mapping BodyPose data to humanoid bones with smooth slerp interpolation. Integrated the controller into CharacterRenderer to apply these poses on top of skeletal animations. Added unit tests for BoneController and updated CharacterRenderer tests to align with the current functional component architecture. Verified all 148 engine tests pass.

---
*PR created automatically by Jules for task [538514089354043202](https://jules.google.com/task/538514089354043202) started by @Fredess74*