### PR TITLE
Bundle Size Audit - April 2026

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,36 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-26
 
 ## Package Sizes
 
-| Package | Size | Comparison | Notes |
-| :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| Package | ES Size (gzip) | CJS Size (gzip) | Change | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| **@Animatica/web** | 102 kB (shared) | N/A | 0K | First Load JS (Next.js 15) |
+| **@Animatica/engine** | 78.8 kB (22.3 kB) | 56.6 kB (18.9 kB) | +7.8K | Core engine logic and R3F components |
+| **@Animatica/editor** | 2,181.2 kB (477.9 kB) | 1,307.8 kB (364.1 kB) | +2105.2K | **CRITICAL REGRESSION**: Three.js/Drei possibly bundled |
+| **@Animatica/platform** | 0.06 kB (0.08 kB) | 0.12 kB (0.14 kB) | -0.14K | Minimal exports only |
+| **@Animatica/contracts** | N/A | N/A | -8K | No compiled artifacts in current build |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3,624.6 kB** (uncompressed ES + CJS total for packages)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (2.1 MB)
+- `dist/index.js`: 2,181.24 kB
+- `dist/index.cjs`: 1,307.75 kB
+- **Issue**: The bundle size suggests that large peer dependencies (like `three`, `@react-three/fiber`, or `@react-three/drei`) are being bundled into the library instead of being treated as external.
 
-## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+### @Animatica/engine (78.8 kB)
+- `dist/index.js`: 78.78 kB
+- `dist/index.cjs`: 56.64 kB
+
+## Changes Since Last Audit (2026-02-25)
+- `@Animatica/editor` exploded from 76K to 2.1MB.
+- `@Animatica/engine` grew slightly from 71K to 78.8K.
+- `@Animatica/web` remains stable at 102K First Load JS.
+- `@Animatica/contracts` no longer reporting size (no output files found by turbo).
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Immediately investigate `vite.config.ts`. Ensure `three`, `@react-three/fiber`, and `@react-three/drei` are in the `external` list of `rollupOptions`.
+- **@Animatica/engine**: Good growth rate, continue monitoring as more features are added.
+- **@Animatica/web**: Monitor `app/create` route as it imports the heavy editor package.


### PR DESCRIPTION
Conducted a full monorepo build and audit of bundle sizes. Documented findings in docs/BUNDLE_REPORT.md, highlighting a significant 2.1MB regression in the @Animatica/editor package likely due to failed dependency externalization.

---
*PR created automatically by Jules for task [14096228490979183228](https://jules.google.com/task/14096228490979183228) started by @Fredess74*