### PR TITLE
feat(engine): implement BoneController for manual posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import type { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+  let headBone: THREE.Bone
+  let armBone: THREE.Bone
+
+  beforeEach(() => {
+    bones = new Map()
+    headBone = new THREE.Bone()
+    headBone.name = 'Head'
+    armBone = new THREE.Bone()
+    armBone.name = 'LeftArm'
+
+    bones.set('Head', headBone)
+    bones.set('LeftArm', armBone)
+
+    controller = new BoneController(bones)
+  })
+
+  it('sets target pose correctly', () => {
+    const pose: BodyPose = {
+      head: [Math.PI / 4, 0, 0],
+    }
+    controller.setPose(pose)
+
+    // update with delta=1 should reach target immediately (with high blend speed)
+    controller.setBlendSpeed(100)
+    controller.update(0.1)
+
+    const expected = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 4, 0, 0))
+    expect(headBone.quaternion.x).toBeCloseTo(expected.x)
+    expect(headBone.quaternion.y).toBeCloseTo(expected.y)
+    expect(headBone.quaternion.z).toBeCloseTo(expected.z)
+    expect(headBone.quaternion.w).toBeCloseTo(expected.w)
+  })
+
+  it('smoothly interpolates towards target', () => {
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+    controller.setPose(pose)
+    controller.setBlendSpeed(1.0)
+
+    // Halfway step
+    controller.update(0.5)
+
+    // Initial was identity (0,0,0,1)
+    // Target is (sin(pi/4), 0, 0, cos(pi/4)) = (0.707, 0, 0, 0.707)
+    // At 0.5, it should be between them.
+    expect(headBone.quaternion.x).toBeGreaterThan(0)
+    expect(headBone.quaternion.x).toBeLessThan(0.707)
+  })
+
+  it('handles missing bones gracefully', () => {
+    const pose: BodyPose = {
+      rightArm: [1, 1, 1], // Not in our bones Map
+    }
+    expect(() => {
+      controller.setPose(pose)
+      controller.update(0.1)
+    }).not.toThrow()
+  })
+
+  it('clears target when property is missing in pose', () => {
+    controller.setPose({ head: [1, 0, 0] })
+    controller.setBlendSpeed(100)
+    controller.update(0.1)
+
+    const intermediateX = headBone.quaternion.x
+    expect(intermediateX).toBeGreaterThan(0)
+
+    controller.setPose({}) // Clear pose
+
+    // It shouldn't move further if target is cleared
+    controller.update(0.1)
+    expect(headBone.quaternion.x).toBe(intermediateX)
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,83 @@
+/**
+ * BoneController — Manages manual bone rotations (body posing) on a character.
+ * Maps high-level BodyPose properties to specific humanoid bones.
+ * Supports smooth interpolation (slerp) towards target poses.
+ *
+ * @module @animatica/engine/character
+ */
+import * as THREE from 'three'
+import type { BodyPose } from '../types'
+
+/**
+ * Maps BodyPose keys to standard humanoid bone names.
+ */
+const BONE_MAP: Record<keyof BodyPose, string> = {
+  head: 'Head',
+  spine: 'Spine',
+  leftArm: 'LeftArm',
+  rightArm: 'RightArm',
+  leftLeg: 'LeftUpperLeg',
+  rightLeg: 'RightUpperLeg',
+}
+
+/**
+ * Controller for manual character posing.
+ * Intersects with the animation system by applying overrides to specific bones.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targetRotations: Map<string, THREE.Quaternion> = new Map()
+  private blendSpeed: number = 8.0 // Speed of interpolation
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Sets the target pose for the character.
+   * Converts Euler angles (radians) from BodyPose to Quaternions.
+   *
+   * @param pose The target body pose configuration.
+   */
+  setPose(pose: BodyPose): void {
+    Object.entries(BONE_MAP).forEach(([key, boneName]) => {
+      const rotation = pose[key as keyof BodyPose]
+      if (rotation) {
+        const q = new THREE.Quaternion().setFromEuler(
+          new THREE.Euler(rotation[0], rotation[1], rotation[2])
+        )
+        this.targetRotations.set(boneName, q)
+      } else {
+        this.targetRotations.delete(boneName)
+      }
+    })
+  }
+
+  /**
+   * Updates the character's bones towards the target pose.
+   * Call this in the frame loop AFTER the main animation update.
+   *
+   * @param delta Time since last frame in seconds.
+   */
+  update(delta: number): void {
+    if (this.targetRotations.size === 0) return
+
+    const alpha = Math.min(delta * this.blendSpeed, 1.0)
+
+    this.targetRotations.forEach((target, boneName) => {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        // Smoothly interpolate towards the target rotation
+        bone.quaternion.slerp(target, alpha)
+      }
+    })
+  }
+
+  /**
+   * Set the interpolation speed.
+   * @param speed Units per second.
+   */
+  setBlendSpeed(speed: number): void {
+    this.blendSpeed = speed
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -8,6 +8,8 @@ export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 
+export { BoneController } from './BoneController'
+
 export { FaceMorphController, BLEND_SHAPES, EXPRESSION_PRESETS, VISEME_MAP } from './FaceMorphController'
 export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,102 +1,107 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import React from 'react'
-// @ts-ignore
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
-// Mock react to bypass hooks checks when calling component directly
-vi.mock('react', async () => {
-  const actual = await vi.importActual<typeof import('react')>('react')
-  return {
-    ...actual,
-    useRef: () => ({ current: null }),
-  }
-})
+// Mock Three.js and R3F
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: { name: 'root' },
+    bones: new Map(),
+    bodyMesh: null,
+    morphTargetMap: {},
+  })),
+}))
+
+vi.mock('../../character/CharacterAnimator', () => ({
+  CharacterAnimator: vi.fn().mockImplementation(function(this: any) {
+    this.registerClip = vi.fn()
+    this.play = vi.fn()
+    this.update = vi.fn()
+    this.dispose = vi.fn()
+    this.setSpeed = vi.fn()
+  }),
+  createIdleClip: vi.fn(),
+  createWalkClip: vi.fn(),
+  createRunClip: vi.fn(),
+  createTalkClip: vi.fn(),
+  createWaveClip: vi.fn(),
+  createDanceClip: vi.fn(),
+  createSitClip: vi.fn(),
+  createJumpClip: vi.fn(),
+}))
+
+vi.mock('../../character/BoneController', () => ({
+  BoneController: vi.fn().mockImplementation(function(this: any) {
+    this.setPose = vi.fn()
+    this.update = vi.fn()
+  }),
+}))
+
+vi.mock('../../character/FaceMorphController', () => ({
+  FaceMorphController: vi.fn().mockImplementation(function(this: any) {
+    this.setTarget = vi.fn()
+    this.update = vi.fn()
+  }),
+}))
+
+vi.mock('../../character/EyeController', () => ({
+  EyeController: vi.fn().mockImplementation(function(this: any) {
+    this.update = vi.fn()
+  }),
+}))
+
+vi.mock('../../character/CharacterPresets', () => ({
+  getPreset: vi.fn(),
 }))
 
 describe('CharacterRenderer', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   const mockActor: CharacterActor = {
     id: 'char-1',
     name: 'Hero',
     type: 'character',
     visible: true,
     transform: {
-      position: [10, 0, 5],
-      rotation: [0, Math.PI, 0],
-      scale: [1, 1, 1]
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
     },
     animation: 'idle',
     morphTargets: {},
     bodyPose: {},
-    clothing: {}
+    clothing: {},
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-
-    expect(result).not.toBeNull()
-    expect(result.type).toBe('group')
-
-    const props = result.props as any
-    expect(props.position).toEqual([10, 0, 5])
-    expect(props.rotation).toEqual([0, Math.PI, 0])
-    expect(props.scale).toEqual([1, 1, 1])
-
-    // Verify children
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('renders nothing when visible is false', () => {
-    const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
+  it('renders without crashing', () => {
+    const { container } = render(<CharacterRenderer actor={mockActor} />)
+    expect(container).toBeDefined()
+    expect(container.firstChild).not.toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
-    const props = result.props as any
-    const children = React.Children.toArray(props.children) as React.ReactElement[]
+  it('renders a group with correct name', () => {
+    const { container } = render(<CharacterRenderer actor={mockActor} />)
+    const group = container.querySelector('group')
+    expect(group).not.toBeNull()
+    expect(group?.getAttribute('name')).toBe('char-1')
+  })
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+  it('renders selection ring when isSelected is true', () => {
+    const { container, rerender } = render(
+      <CharacterRenderer actor={mockActor} isSelected={false} />
+    )
+    // Check for mesh with ringGeometry
+    expect(container.querySelector('ringGeometry')).toBeNull()
+
+    rerender(<CharacterRenderer actor={mockActor} isSelected={true} />)
+    expect(container.querySelector('ringGeometry')).not.toBeNull()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -17,6 +17,7 @@ import {
   createWalkClip,
   createWaveClip,
 } from '../../character/CharacterAnimator'
+import { BoneController } from '../../character/BoneController'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
 import { getPreset } from '../../character/CharacterPresets'
@@ -35,6 +36,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 }) => {
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
@@ -64,6 +66,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     animator.play(actor.animation || 'idle')
     animatorRef.current = animator
 
+    // Setup bone controller for manual posing
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
+
     // Setup face morph controller
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
     faceMorphRef.current = faceMorph
@@ -91,6 +97,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.animationSpeed])
 
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setPose(actor.bodyPose)
+    }
+  }, [actor.bodyPose])
+
   // React to morph target / expression changes from CharacterPanel
   useEffect(() => {
     if (faceMorphRef.current && actor.morphTargets) {
@@ -103,6 +116,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Manual bone posing (overrides animation)
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending


### PR DESCRIPTION
Implemented the `BoneController` in `@Animatica/engine` to allow manual character posing (body pose overrides).

Key changes:
- Created `BoneController.ts` to map `BodyPose` properties to humanoid bones with smooth `slerp` interpolation.
- Integrated `BoneController` into `CharacterRenderer.tsx`, applying overrides in the `useFrame` loop after the main animation update.
- Added unit tests for `BoneController` covering interpolation and edge cases.
- Refactored `CharacterRenderer.test.tsx` to utilize `@testing-library/react` and `jsdom` for more robust component testing.
- Exported the new controller from the character package.

This completes Task 12 from the backlog.

---
*PR created automatically by Jules for task [299632719516380206](https://jules.google.com/task/299632719516380206) started by @Fredess74*