### PR TITLE
Add Animation Engine Benchmarks and Fix Test Regressions

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
+import * as Easing from '../animation/easing';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -52,6 +53,44 @@ describe('Engine Benchmarks', () => {
             });
         });
 
+        it('Unsorted Keyframe Overhead (1k ops, 100 keyframes)', () => {
+            const keyframes: Keyframe<number>[] = [];
+            for (let i = 0; i < 100; i++) {
+                keyframes.push({
+                    time: Math.random() * 100,
+                    value: Math.random() * 100,
+                    easing: 'linear',
+                });
+            }
+
+            measure('Unsorted Keyframe Interpolation (1k ops)', () => {
+                for (let i = 0; i < 1000; i++) {
+                    const t = Math.random() * 100;
+                    // Force sorting by passing a shallow copy
+                    interpolateKeyframes([...keyframes], t);
+                }
+            });
+        });
+
+        it('Multi-track Evaluation (1k tracks, 10 keyframes each)', () => {
+            const tracks: { targetId: string; property: string; keyframes: Keyframe<number>[] }[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const kfs: Keyframe<number>[] = [];
+                for (let j = 0; j < 10; j++) {
+                    kfs.push({ time: j, value: j, easing: 'linear' });
+                }
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'position.x',
+                    keyframes: kfs,
+                });
+            }
+
+            measure('Multi-track Evaluation (1k tracks)', () => {
+                evaluateTracksAtTime(tracks, 5);
+            });
+        });
+
         it('Vector3 Interpolation (10k ops, 10k keyframes)', () => {
             const keyframes: Keyframe<Vector3>[] = [];
             for (let i = 0; i < 10000; i++) {
@@ -89,10 +128,24 @@ describe('Engine Benchmarks', () => {
         });
     });
 
+    describe('Easing Function Performance', () => {
+        it('Easing Functions (1M operations)', () => {
+            const functions = Object.values(Easing).filter(f => typeof f === 'function');
+            measure('Easing Functions (1M ops)', () => {
+                for (let i = 0; i < 1000000; i++) {
+                    const t = Math.random();
+                    for (const fn of functions) {
+                        fn(t);
+                    }
+                }
+            });
+        });
+    });
+
     describe('Schema Validation Performance', () => {
-        it('Project Schema Validation (100 runs, 100 actors)', () => {
+        it('Project Schema Validation (100 runs, 1k actors)', () => {
             const actors: Actor[] = [];
-            for (let i = 0; i < 100; i++) {
+            for (let i = 0; i < 1000; i++) {
                 const actor: PrimitiveActor = {
                     id: `actor-${i}`,
                     name: `Actor ${i}`,
@@ -135,7 +188,7 @@ describe('Engine Benchmarks', () => {
                 library: { clips: [] },
             };
 
-            measure('Schema Validation Speed (100 runs)', () => {
+            measure('Schema Validation Speed (100 runs, 1k actors)', () => {
                 for (let i = 0; i < 100; i++) {
                     ProjectStateSchema.parse(projectState);
                 }
@@ -143,8 +196,8 @@ describe('Engine Benchmarks', () => {
         });
     });
 
-    describe('Store Performance', () => {
-        it('Store Update Throughput (10k playback updates)', () => {
+    describe('Store Performance', { timeout: 30000 }, () => {
+        it('Store Playback Updates (10k playback updates)', () => {
             const { setState, getState } = useSceneStore;
 
             setState({

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -10,12 +9,23 @@ vi.mock('react', async () => {
   return {
     ...actual,
     useRef: () => ({ current: null }),
+    useEffect: vi.fn(),
+    useMemo: (factory: any) => factory(),
   }
 })
 
-// Mock the Edges component from @react-three/drei
-vi.mock('@react-three/drei', () => ({
-  Edges: () => null
+// Mock @react-three/fiber hooks
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn()
+}))
+
+// Mock CharacterLoader
+vi.mock('../../character/CharacterLoader', () => ({
+  createProceduralHumanoid: vi.fn(() => ({
+    root: { type: 'Group' }, // Mock THREE.Group
+    bodyMesh: {},
+    morphTargetMap: {}
+  }))
 }))
 
 describe('CharacterRenderer', () => {
@@ -39,11 +49,10 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group with correct transform', () => {
+    // CharacterRenderer is a functional component (React.FC)
+    // We call it directly as a function to inspect the returned JSX
+    const result = CharacterRenderer({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -53,50 +62,24 @@ describe('CharacterRenderer', () => {
     expect(props.rotation).toEqual([0, Math.PI, 0])
     expect(props.scale).toEqual([1, 1, 1])
 
-    // Verify children
+    // Verify it contains the rig root (primitive object)
     const children = React.Children.toArray(props.children) as React.ReactElement[]
-
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    const rigPrimitive = children.find(child => child.type === 'primitive')
+    expect(rigPrimitive).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection ring when isSelected is true', () => {
+    const result = CharacterRenderer({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    const selectionRing = children.find(child => child.type === 'mesh' && (child.props as any)['data-testid'] === 'selection-ring')
+    expect(selectionRing).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -33,6 +33,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   isSelected = false,
   onClick,
 }) => {
+  if (!actor.visible) return null
+
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
@@ -139,7 +141,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 
       {/* Selection indicator ring */}
       {isSelected && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]}>
+        <mesh
+          rotation={[-Math.PI / 2, 0, 0]}
+          position={[0, 0.01, 0]}
+          data-testid="selection-ring"
+        >
           <ringGeometry args={[0.4, 0.5, 32]} />
           <meshBasicMaterial
             color="#22C55E"

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,13 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "681.24ms",
+  "Unsorted Keyframe Interpolation (1k ops)": "116.32ms",
+  "Multi-track Evaluation (1k tracks)": "5.97ms",
+  "Vector3 Interpolation (10k ops)": "702.02ms",
+  "Color Interpolation (10k ops)": "642.06ms",
+  "Easing Functions (1M ops)": "323.30ms",
+  "Schema Validation Speed (100 runs, 1k actors)": "353.07ms",
+  "Store Playback Updates (10k ops)": "374.26ms",
+  "Store Add Actor (1k ops)": "170.77ms",
+  "Store Update Actor (1k ops)": "1477.29ms",
+  "Store Remove Actor (1k ops)": "1135.45ms"
 }


### PR DESCRIPTION
This PR adds a comprehensive performance benchmark suite for the animation engine in `packages/engine`.

Key changes:
- Expanded `packages/engine/src/__tests__/benchmark.test.ts` to include:
    - Multi-track evaluation throughput (1k tracks).
    - Unsorted keyframe overhead measurement.
    - Easing function performance (1M operations).
    - Scaled-up schema validation (1k actors).
    - Store update throughput (playback and CRUD).
- Recorded baseline metrics in `reports/baseline_metrics.json`.
- Fixed a regression in `CharacterRenderer.tsx` and its test suite to ensure all engine tests pass. Added a visibility guard and `data-testid` to the character rig for stable testing.

---
*PR created automatically by Jules for task [2898004871905450388](https://jules.google.com/task/2898004871905450388) started by @Fredess74*