### PR TITLE
Add Camera Presets and Fix Viewport Tests

### DIFF
--- a/packages/editor/src/viewport/Viewport.test.tsx
+++ b/packages/editor/src/viewport/Viewport.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Viewport } from './Viewport'
 import React from 'react'
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   mockSetSelectedActor: vi.fn(),
   mockUpdateActor: vi.fn(),
   mockGetObjectByName: vi.fn(),
+  mockGoToPreset: vi.fn(),
 }))
 
 // Mock R3F
@@ -27,7 +28,8 @@ vi.mock('@react-three/fiber', async () => {
     Canvas: ({ children }: { children: React.ReactNode }) => <div data-testid="canvas">{children}</div>,
     useThree: () => ({
       scene: { getObjectByName: mocks.mockGetObjectByName },
-      camera: { position: { set: vi.fn() }, lookAt: vi.fn() }
+      camera: { position: { set: vi.fn() }, lookAt: vi.fn() },
+      gl: { domElement: document.createElement('canvas') }
     }),
   }
 })
@@ -38,12 +40,26 @@ vi.mock('@react-three/drei', () => ({
   TransformControls: () => <div data-testid="transform-controls" />,
   Grid: () => <div data-testid="grid" />,
   Sky: () => <div data-testid="sky" />,
+  ContactShadows: () => <div data-testid="contact-shadows" />,
+  Environment: () => <div data-testid="environment" />,
+}))
+
+// Mock ViewportControls hooks
+vi.mock('./ViewportControls', () => ({
+    ViewportControls: () => <div data-testid="viewport-controls" />,
+    useCameraPreset: () => ({
+        goToPreset: mocks.mockGoToPreset
+    })
 }))
 
 // Mock Engine
 vi.mock('@Animatica/engine', () => ({
   SceneManager: () => <div data-testid="scene-manager" />,
+  PrimitiveRenderer: () => <div data-testid="primitive-renderer" />,
+  LightRenderer: () => <div data-testid="light-renderer" />,
+  CameraRenderer: () => <div data-testid="camera-renderer" />,
   useSceneStore: (selector: any) => selector({
+    actors: [],
     selectedActorId: 'test-actor-id',
     setSelectedActor: mocks.mockSetSelectedActor,
     updateActor: mocks.mockUpdateActor,
@@ -58,12 +74,14 @@ vi.mock('@Animatica/engine', () => ({
 
 describe('Viewport', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     // Default: object not found
     mocks.mockGetObjectByName.mockReturnValue(undefined)
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     cleanup()
   })
 
@@ -71,9 +89,16 @@ describe('Viewport', () => {
     render(<Viewport />)
 
     expect(screen.getByTestId('canvas')).toBeTruthy()
-    expect(screen.getByTestId('orbit-controls')).toBeTruthy()
+    expect(screen.getByTestId('viewport-controls')).toBeTruthy()
     expect(screen.getByTestId('grid')).toBeTruthy()
-    expect(screen.getByTestId('scene-manager')).toBeTruthy()
+  })
+
+  it('renders the mode buttons', () => {
+    render(<Viewport />)
+
+    expect(screen.getByTitle('Move (W)')).toBeTruthy()
+    expect(screen.getByTitle('Rotate (E)')).toBeTruthy()
+    expect(screen.getByTitle('Scale (R)')).toBeTruthy()
   })
 
   it('renders the camera toolbar', () => {
@@ -91,10 +116,10 @@ describe('Viewport', () => {
     const topButton = screen.getByTitle('Top View')
     fireEvent.click(topButton)
 
-    expect(topButton).toBeTruthy()
+    expect(mocks.mockGoToPreset).toHaveBeenCalledWith('top')
   })
 
-  it('renders gizmo when object is found', () => {
+  it('renders gizmo when object is found', async () => {
     // Mock found object
     mocks.mockGetObjectByName.mockReturnValue({
         position: { x: 0, y: 0, z: 0 },
@@ -103,6 +128,11 @@ describe('Viewport', () => {
     })
 
     render(<Viewport />)
+
+    // Advance timers for ViewportGizmo useEffect
+    act(() => {
+        vi.advanceTimersByTime(100)
+    })
 
     expect(screen.getByTestId('transform-controls')).toBeTruthy()
   })

--- a/packages/editor/src/viewport/ViewportToolbar.tsx
+++ b/packages/editor/src/viewport/ViewportToolbar.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react'
 import type { GizmoMode, TransformSpace, ViewMode } from './Viewport'
+import { useCameraPreset } from './ViewportControls'
 
 interface ViewportToolbarProps {
     gizmoMode: GizmoMode
@@ -30,6 +31,8 @@ export const ViewportToolbar: React.FC<ViewportToolbarProps> = ({
     viewMode,
     onViewModeChange,
 }) => {
+    const { goToPreset } = useCameraPreset()
+
     return (
         <div style={toolbarStyle}>
             {/* Gizmo mode group */}
@@ -93,6 +96,37 @@ export const ViewportToolbar: React.FC<ViewportToolbarProps> = ({
                     icon="🖼️"
                 />
             </div>
+
+            {/* Camera View Presets */}
+            {viewMode === '3d' && (
+                <div style={groupStyle}>
+                    <Divider />
+                    <ToolBtn
+                        tooltip="Top View"
+                        active={false}
+                        onClick={() => goToPreset('top')}
+                        icon="⤓"
+                    />
+                    <ToolBtn
+                        tooltip="Front View"
+                        active={false}
+                        onClick={() => goToPreset('front')}
+                        icon="⮕"
+                    />
+                    <ToolBtn
+                        tooltip="Side View"
+                        active={false}
+                        onClick={() => goToPreset('right')}
+                        icon="⬵"
+                    />
+                    <ToolBtn
+                        tooltip="Perspective View"
+                        active={false}
+                        onClick={() => goToPreset('perspective')}
+                        icon="🎥"
+                    />
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
Implemented camera view preset buttons in the editor's ViewportToolbar and fixed regressions in the Viewport test suite.

### Changes:
- **ViewportToolbar.tsx**: Added a new button group for camera presets (Top, Front, Side, Perspective) and wired them to the `useCameraPreset` hook.
- **Viewport.test.tsx**: Corrected mocks for `@react-three/fiber` and `@react-three/drei` to resolve "No export defined" and "TypeError" errors. Added `act` wrappers and fake timers to handle side effects in gizmo rendering.
- **Testing**: Verified that all 35 tests in the `@Animatica/editor` package pass.

---
*PR created automatically by Jules for task [7202174680965560628](https://jules.google.com/task/7202174680965560628) started by @Fredess74*