### PR TITLE
chore(bundle): size audit 2026-04-28

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-04-28
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 102 kB | 0K | First Load JS (Stable) |
+| **@Animatica/engine** | 78.8 kB | +7.8K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 2.1 MB | +2.0M | **REGRESSION**: Bundling Three.js, R3F, and Drei |
+| **@Animatica/platform** | 0.1 kB | -0.1K | Minimal exports |
+| **@Animatica/contracts** | 0 kB | -8K | No compiled artifacts |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**2.2 MB** (excluding web), **2.3 MB** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (2.1 MB)
+- `dist/index.js`: 2,181.24 kB
+- `dist/index.cjs`: 1,307.75 kB
+- **Root Cause**: `three`, `@react-three/fiber`, and `@react-three/drei` are listed in `dependencies` and NOT externalized in `vite.config.ts`.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (78.8 kB)
+- `dist/index.js`: 78.78 kB
+- `dist/index.cjs`: 56.64 kB
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-04-28.
+- **CRITICAL**: `@Animatica/editor` has ballooned from 76K to 2.1MB.
+- This regression was previously identified in memory (April 27, 2026) and remains unresolved.
+- dependencies in `packages/editor/package.json` need to be moved to `peerDependencies` and added to `rollupOptions.external` in `vite.config.ts`.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Immediate action required to externalize `three` and `@react-three` suites to restore bundle size.
+- **@Animatica/engine**: Size is creeping up but remains within acceptable limits (under 100K).
+- **@Animatica/web**: Stable at 102 kB First Load JS.


### PR DESCRIPTION
This PR provides a comprehensive bundle size audit as of April 28, 2026. 

Key findings:
- @Animatica/web: 102 kB (Stable)
- @Animatica/engine: 78.8 kB (Acceptable growth)
- @Animatica/editor: 2.1 MB (CRITICAL REGRESSION)
- @Animatica/platform: 0.1 kB
- @Animatica/contracts: 0 kB

The audit identifies a major regression in @Animatica/editor caused by the accidental bundling of 'three', '@react-three/fiber', and '@react-three/drei'. These dependencies are currently in 'dependencies' and not 'peerDependencies', and are not being externalized in the Vite config.

Recommendations for immediate follow-up:
1. Move Three.js and R3F dependencies to peerDependencies in packages/editor/package.json.
2. Update packages/editor/vite.config.ts to externalize these packages.
3. Investigate pre-existing test failures in Viewport.test.tsx and CharacterRenderer.test.tsx.

---
*PR created automatically by Jules for task [5356986728950872599](https://jules.google.com/task/5356986728950872599) started by @Fredess74*