### PR TITLE
feat(engine): implement manual bone posing with BoneController (#12)

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { BoneController } from './BoneController';
+import { BodyPose } from '../types';
+
+describe('BoneController', () => {
+    let bones: Map<string, THREE.Bone>;
+    let controller: BoneController;
+
+    beforeEach(() => {
+        bones = new Map();
+
+        const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg'];
+        boneNames.forEach(name => {
+            const bone = new THREE.Bone();
+            bone.name = name;
+            bones.set(name, bone);
+        });
+
+        controller = new BoneController(bones);
+        // Set lerp speed high to make tests near-instant (or delta=1)
+        controller.setLerpSpeed(1000);
+    });
+
+    it('should apply rotation to bones based on BodyPose', () => {
+        const pose: BodyPose = {
+            head: [0.1, 0.2, 0.3],
+            leftArm: [1, 0, 0]
+        };
+
+        // Use a large delta to ensure it reaches target in one step due to high lerpSpeed
+        controller.update(pose, 1);
+
+        const head = bones.get('Head')!;
+        const leftArm = bones.get('LeftArm')!;
+
+        expect(head.rotation.x).toBeCloseTo(0.1);
+        expect(head.rotation.y).toBeCloseTo(0.2);
+        expect(head.rotation.z).toBeCloseTo(0.3);
+
+        expect(leftArm.rotation.x).toBeCloseTo(1);
+        expect(leftArm.rotation.y).toBeCloseTo(0);
+        expect(leftArm.rotation.z).toBeCloseTo(0);
+    });
+
+    it('should smoothly interpolate towards target rotation', () => {
+        controller.setLerpSpeed(10);
+        const pose: BodyPose = {
+            head: [1, 0, 0]
+        };
+
+        // Small delta, should not reach target
+        controller.update(pose, 0.01);
+
+        const head = bones.get('Head')!;
+        expect(head.rotation.x).toBeGreaterThan(0);
+        expect(head.rotation.x).toBeLessThan(1);
+    });
+
+    it('should handle missing bones gracefully', () => {
+        const partialBones = new Map<string, THREE.Bone>();
+        const headBone = new THREE.Bone();
+        headBone.name = 'Head';
+        partialBones.set('Head', headBone);
+
+        const partialController = new BoneController(partialBones);
+        const pose: BodyPose = {
+            head: [0.5, 0.5, 0.5],
+            spine: [1, 1, 1] // Bone doesn't exist in map
+        };
+
+        expect(() => partialController.update(pose, 1)).not.toThrow();
+        expect(headBone.rotation.x).toBeCloseTo(0.5);
+    });
+});

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,61 @@
+import * as THREE from 'three';
+import { BodyPose, Vector3 } from '../types';
+
+/**
+ * BoneController — Manages manual character posing by mapping abstract BodyPose
+ * properties to actual skeleton bone rotations.
+ *
+ * Supports smooth interpolation between poses using slerp.
+ */
+export class BoneController {
+    private bones: Map<string, THREE.Bone>;
+    private lerpSpeed = 10;
+
+    // Scratch variables to avoid object churn in the animation loop
+    private static readonly _euler = new THREE.Euler();
+    private static readonly _quaternion = new THREE.Quaternion();
+
+    constructor(bones: Map<string, THREE.Bone>) {
+        this.bones = bones;
+    }
+
+    /**
+     * Updates bone rotations based on the provided BodyPose.
+     * Should be called every frame after the main animation update.
+     *
+     * @param pose The desired body pose.
+     * @param delta Time since last frame in seconds.
+     */
+    update(pose: BodyPose, delta: number): void {
+        if (pose.head) this.applyRotation('Head', pose.head, delta);
+        if (pose.spine) this.applyRotation('Spine', pose.spine, delta);
+        if (pose.leftArm) this.applyRotation('LeftArm', pose.leftArm, delta);
+        if (pose.rightArm) this.applyRotation('RightArm', pose.rightArm, delta);
+        if (pose.leftLeg) this.applyRotation('LeftUpperLeg', pose.leftLeg, delta);
+        if (pose.rightLeg) this.applyRotation('RightUpperLeg', pose.rightLeg, delta);
+    }
+
+    /**
+     * Internal helper to apply rotation to a specific bone using slerp.
+     */
+    private applyRotation(boneName: string, rotation: Vector3, delta: number): void {
+        const bone = this.bones.get(boneName);
+        if (bone) {
+            // Use scratch variables
+            BoneController._euler.set(rotation[0], rotation[1], rotation[2]);
+            BoneController._quaternion.setFromEuler(BoneController._euler);
+
+            // Smoothly interpolate to the target rotation
+            // Use Math.min(1, ...) to prevent overshooting if delta is large
+            bone.quaternion.slerp(BoneController._quaternion, Math.min(1, delta * this.lerpSpeed));
+        }
+    }
+
+    /**
+     * Sets the interpolation speed for pose transitions.
+     * @param speed Speed value (default: 10).
+     */
+    setLerpSpeed(speed: number): void {
+        this.lerpSpeed = speed;
+    }
+}

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -20,6 +20,7 @@ import {
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
 import { getPreset } from '../../character/CharacterPresets'
+import { BoneController } from '../../character/BoneController'
 import type { CharacterActor } from '../../types'
 
 interface CharacterRendererProps {
@@ -37,6 +38,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
 
   // Build character rig
   const rig = useMemo(() => {
@@ -72,6 +74,10 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     const eyeController = new EyeController()
     eyeControllerRef.current = eyeController
 
+    // Setup bone controller for manual posing
+    const boneController = new BoneController(rig.bones)
+    boneControllerRef.current = boneController
+
     return () => {
       animator.dispose()
     }
@@ -103,6 +109,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Manual bone posing (applied after animation)
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.update(actor.bodyPose, delta)
     }
 
     // Face morph blending


### PR DESCRIPTION
This PR implements Task 12: Bone Controller.

The `BoneController` class is added to `packages/engine/src/character/BoneController.ts`. It maps abstract `BodyPose` properties (head, spine, leftArm, rightArm, leftLeg, rightLeg) to specific bones in the THREE.js skeleton. It uses `slerp` for smooth transitions between poses.

To ensure high performance within the animation loop, the controller uses static scratch variables for Euler and Quaternion objects, avoiding object creation and garbage collection pressure.

The controller is integrated into `CharacterRenderer.tsx` and updated in the `useFrame` loop after the main animation update, allowing manual poses to be applied on top of or as overrides to skeletal animations.

Comprehensive unit tests are provided in `BoneController.test.ts`.

---
*PR created automatically by Jules for task [18407886092480681271](https://jules.google.com/task/18407886092480681271) started by @Fredess74*