### PR TITLE
Bundle Size Audit - May 2, 2026

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-02
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 102 kB | 0 kB | First Load JS (stable) |
+| **@Animatica/engine** | 135.42 kB | +64.42 kB | Includes index.js (78.78 kB) and index.cjs (56.64 kB) |
+| **@Animatica/editor** | 3,488.99 kB | +3,412.99 kB | Includes index.js (2,181.24 kB) and index.cjs (1,307.75 kB) |
+| **@Animatica/platform** | 0.18 kB | -0.02 kB | Minimal exports only |
+| **@Animatica/contracts** | 4 kB | -4 kB | Cache size |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3,628.59 kB** (excluding web), **3,730.59 kB** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3,488.99 kB)
+- `dist/index.js`: 2,181.24 kB
+- `dist/index.cjs`: 1,307.75 kB
+- **CRITICAL REGRESSION**: Size increased significantly due to bundling Three.js, @react-three/fiber, and @react-three/drei instead of externalizing them.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.42 kB)
+- `dist/index.js`: 78.78 kB
+- `dist/index.cjs`: 56.64 kB
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-02.
+- Major regression detected in `@Animatica/editor`.
+- `@Animatica/engine` size has grown as more core features and R3F components were added.
+- `@Animatica/web` remains stable at 102 kB First Load JS.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: IMMEDIATELY externalize `three`, `@react-three/fiber`, and `@react-three/drei` in the Vite build configuration to reduce bundle size.
+- **@Animatica/engine**: Continue to monitor as animation logic expands.
+- **@Animatica/web**: Monitor first-load JS as more editor features are integrated into the main application.

--- a/packages/editor/src/viewport/Viewport.test.tsx
+++ b/packages/editor/src/viewport/Viewport.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@react-three/fiber', async () => {
     ...actual,
     Canvas: ({ children }: { children: React.ReactNode }) => <div data-testid="canvas">{children}</div>,
     useThree: () => ({
+      gl: { domElement: { onpointerdown: null } },
       scene: { getObjectByName: mocks.mockGetObjectByName },
       camera: { position: { set: vi.fn() }, lookAt: vi.fn() }
     }),
@@ -36,24 +37,40 @@ vi.mock('@react-three/fiber', async () => {
 vi.mock('@react-three/drei', () => ({
   OrbitControls: () => <div data-testid="orbit-controls" />,
   TransformControls: () => <div data-testid="transform-controls" />,
+  GizmoHelper: () => <div data-testid="gizmo-helper" />,
+  GizmoViewport: () => <div data-testid="gizmo-viewport" />,
   Grid: () => <div data-testid="grid" />,
   Sky: () => <div data-testid="sky" />,
+  ContactShadows: () => <div data-testid="contact-shadows" />,
+  Environment: () => <div data-testid="environment" />,
 }))
 
 // Mock Engine
 vi.mock('@Animatica/engine', () => ({
   SceneManager: () => <div data-testid="scene-manager" />,
-  useSceneStore: (selector: any) => selector({
-    selectedActorId: 'test-actor-id',
-    setSelectedActor: mocks.mockSetSelectedActor,
-    updateActor: mocks.mockUpdateActor,
-    playback: { isPlaying: false },
-    environment: {
-      ambientLight: { intensity: 0.5, color: '#fff' },
-      sun: { position: [10, 10, 10], intensity: 1, color: '#fff' },
-      skyColor: '#87ceeb',
-    },
-  }),
+  PrimitiveRenderer: () => <div data-testid="primitive-renderer" />,
+  LightRenderer: () => <div data-testid="light-renderer" />,
+  CameraRenderer: () => <div data-testid="camera-renderer" />,
+  useSceneStore: (selector: any) => {
+    const state = {
+      actors: [{ id: 'test-actor-id', type: 'primitive', visible: true, transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] } }],
+      selectedActorId: 'test-actor-id',
+      setSelectedActor: mocks.mockSetSelectedActor,
+      updateActor: mocks.mockUpdateActor,
+      playback: { isPlaying: false },
+      environment: {
+        ambientLight: { intensity: 0.5, color: '#fff' },
+        sun: { position: [10, 10, 10], intensity: 1, color: '#fff' },
+        skyColor: '#87ceeb',
+      },
+      camera: {
+        track: {
+          keyframes: []
+        }
+      }
+    }
+    return typeof selector === 'function' ? selector(state) : state
+  },
 }))
 
 describe('Viewport', () => {
@@ -73,28 +90,27 @@ describe('Viewport', () => {
     expect(screen.getByTestId('canvas')).toBeTruthy()
     expect(screen.getByTestId('orbit-controls')).toBeTruthy()
     expect(screen.getByTestId('grid')).toBeTruthy()
-    expect(screen.getByTestId('scene-manager')).toBeTruthy()
+    expect(screen.getByTestId('primitive-renderer')).toBeTruthy()
   })
 
-  it('renders the camera toolbar', () => {
+  it('renders the viewport toolbar', () => {
     render(<Viewport />)
 
-    expect(screen.getByTitle('Top View')).toBeTruthy()
-    expect(screen.getByTitle('Front View')).toBeTruthy()
-    expect(screen.getByTitle('Side View')).toBeTruthy()
-    expect(screen.getByTitle('Perspective View')).toBeTruthy()
+    expect(screen.getByTitle('Move (W)')).toBeTruthy()
+    expect(screen.getByTitle('Rotate (E)')).toBeTruthy()
+    expect(screen.getByTitle('Scale (R)')).toBeTruthy()
   })
 
-  it('attempts to change camera view when toolbar button clicked', () => {
+  it('attempts to change gizmo mode when toolbar button clicked', () => {
     render(<Viewport />)
 
-    const topButton = screen.getByTitle('Top View')
-    fireEvent.click(topButton)
+    const rotateButton = screen.getByTitle('Rotate (E)')
+    fireEvent.click(rotateButton)
 
-    expect(topButton).toBeTruthy()
+    expect(rotateButton).toBeTruthy()
   })
 
-  it('renders gizmo when object is found', () => {
+  it('renders gizmo when object is found', async () => {
     // Mock found object
     mocks.mockGetObjectByName.mockReturnValue({
         position: { x: 0, y: 0, z: 0 },
@@ -104,6 +120,8 @@ describe('Viewport', () => {
 
     render(<Viewport />)
 
-    expect(screen.getByTestId('transform-controls')).toBeTruthy()
+    // ViewportGizmo has a 50ms timeout before setting the target
+    const gizmo = await screen.findByTestId('transform-controls')
+    expect(gizmo).toBeTruthy()
   })
 })

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "455.06ms",
+  "Vector3 Interpolation (10k ops)": "530.28ms",
+  "Color Interpolation (10k ops)": "479.05ms",
+  "Schema Validation Speed (100 runs)": "93.78ms",
+  "Store Playback Updates (10k ops)": "273.33ms",
+  "Store Add Actor (1k ops)": "142.34ms",
+  "Store Update Actor (1k ops)": "1239.79ms",
+  "Store Remove Actor (1k ops)": "1048.52ms"
 }


### PR DESCRIPTION
Performed a comprehensive bundle size audit for the Animatica monorepo.
- Ran `pnpm build` to generate production artifacts.
- Calculated and documented sizes for all packages in `docs/BUNDLE_REPORT.md`.
- Identified a major regression in `@Animatica/editor` (3.4 MB) due to bundled R3F/Three.js dependencies.
- Updated `packages/editor/src/viewport/Viewport.test.tsx` to align with the current UI and fix failures caused by missing mocks.
- Updated `reports/baseline_metrics.json` with the latest performance data.

---
*PR created automatically by Jules for task [3810293701037762469](https://jules.google.com/task/3810293701037762469) started by @Fredess74*