### PR TITLE
Fix CharacterRenderer regressions and stabilize test suite

### DIFF
--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -10,8 +10,16 @@ vi.mock('react', async () => {
   return {
     ...actual,
     useRef: () => ({ current: null }),
+    useMemo: (fn: any) => fn(),
+    useEffect: () => {},
+    useImperativeHandle: () => {},
   }
 })
+
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: () => {},
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
@@ -39,7 +47,7 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
+  it('renders a group containing primitive rig with correct transform', () => {
     // Call the forwardRef component's render function directly
     // Since it's wrapped in memo, we access the underlying forwardRef via .type
     // @ts-ignore
@@ -56,28 +64,10 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // First child should be the primitive rig
+    const primitive = children[0]
+    expect(primitive.type).toBe('primitive')
+    expect(primitive.props.object).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
@@ -87,16 +77,16 @@ describe('CharacterRenderer', () => {
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
+  it('renders selection ring when selected', () => {
      // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const result = CharacterRenderer.type.render({ actor: mockActor, isSelected: true }, null) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Second child should be the selection ring mesh
+    const selectionRing = children[1]
+    expect(selectionRing.type).toBe('mesh')
+    const ringChildren = React.Children.toArray(selectionRing.props.children) as React.ReactElement[]
+    expect(ringChildren.some(c => c.type === 'ringGeometry')).toBe(true)
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -2,7 +2,7 @@
  * CharacterRenderer — R3F component for rendering a character actor.
  * Creates a procedural humanoid (or loads GLB), applies animation, face morphs, and eye tracking.
  */
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, memo, forwardRef, useImperativeHandle } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { createProceduralHumanoid } from '../../character/CharacterLoader'
@@ -28,12 +28,15 @@ interface CharacterRendererProps {
   onClick?: () => void
 }
 
-export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
+export const CharacterRenderer = memo(forwardRef<THREE.Group, CharacterRendererProps>(({
   actor,
   isSelected = false,
   onClick,
-}) => {
+}, ref) => {
   const groupRef = useRef<THREE.Group>(null)
+
+  useImperativeHandle(ref, () => groupRef.current!)
+
   const animatorRef = useRef<CharacterAnimator | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
@@ -121,6 +124,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   })
 
+  if (!actor.visible) return null
+
   return (
     <group
       ref={groupRef}
@@ -151,4 +156,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       )}
     </group>
   )
-}
+}))
+
+CharacterRenderer.displayName = 'CharacterRenderer'


### PR DESCRIPTION
Wrapped CharacterRenderer in React.memo and React.forwardRef, implemented useImperativeHandle to expose the group ref, and added a visibility check. Updated CharacterRenderer.test.tsx with necessary hook mocks and corrected assertions to match the current implementation. Verified that all 144 tests in packages/engine pass.

---
*PR created automatically by Jules for task [8172321827984625505](https://jules.google.com/task/8172321827984625505) started by @Fredess74*