### PR TITLE
Add Animation Engine Benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, afterAll } from 'vitest';
-import { interpolateKeyframes } from '../animation/interpolate';
+import { interpolateKeyframes, evaluateTracksAtTime } from '../animation/interpolate';
+import * as Easing from '../animation/easing';
 import { ProjectStateSchema } from '../importer/schemas';
 import { useSceneStore } from '../store/sceneStore';
 import type { Keyframe, ProjectState, Actor, PrimitiveActor, Vector3 } from '../types';
@@ -87,12 +88,43 @@ describe('Engine Benchmarks', () => {
                 }
             });
         });
+
+        it('Easing Functions (1M ops)', () => {
+            measure('Easing Functions 1M ops', () => {
+                for (let i = 0; i < 1000000; i++) {
+                    const t = Math.random();
+                    Easing.easeInOut(t);
+                    Easing.bounce(t);
+                    Easing.elastic(t);
+                }
+            });
+        });
+
+        it('Multi-track Evaluation (1k tracks)', () => {
+            const tracks = [];
+            for (let i = 0; i < 1000; i++) {
+                tracks.push({
+                    targetId: `actor-${i}`,
+                    property: 'transform.position',
+                    keyframes: [
+                        { time: 0, value: [0, 0, 0], easing: 'easeInOut' },
+                        { time: 10, value: [10, 10, 10], easing: 'easeInOut' }
+                    ]
+                });
+            }
+
+            measure('Multi-track Evaluation 1k tracks', () => {
+                for (let i = 0; i < 100; i++) {
+                    evaluateTracksAtTime(tracks as any, Math.random() * 10);
+                }
+            });
+        });
     });
 
     describe('Schema Validation Performance', () => {
-        it('Project Schema Validation (100 runs, 100 actors)', () => {
+        it('Project Schema Validation (100 runs, 1k actors)', () => {
             const actors: Actor[] = [];
-            for (let i = 0; i < 100; i++) {
+            for (let i = 0; i < 1000; i++) {
                 const actor: PrimitiveActor = {
                     id: `actor-${i}`,
                     name: `Actor ${i}`,
@@ -135,7 +167,7 @@ describe('Engine Benchmarks', () => {
                 library: { clips: [] },
             };
 
-            measure('Schema Validation Speed (100 runs)', () => {
+            measure('Schema Validation 1k actors', () => {
                 for (let i = 0; i < 100; i++) {
                     ProjectStateSchema.parse(projectState);
                 }
@@ -144,7 +176,7 @@ describe('Engine Benchmarks', () => {
     });
 
     describe('Store Performance', () => {
-        it('Store Update Throughput (10k playback updates)', () => {
+        it('Store Update Throughput (10k playback updates)', { timeout: 15000 }, () => {
             const { setState, getState } = useSceneStore;
 
             setState({
@@ -167,7 +199,7 @@ describe('Engine Benchmarks', () => {
             });
         });
 
-        it('Store Actor CRUD Throughput (1k actors)', () => {
+        it('Store Actor CRUD Throughput (1k actors)', { timeout: 15000 }, () => {
             const { setState, getState } = useSceneStore;
 
             setState({

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,12 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "446.40ms",
+  "Vector3 Interpolation (10k ops)": "553.14ms",
+  "Color Interpolation (10k ops)": "471.72ms",
+  "Easing Functions 1M ops": "73.55ms",
+  "Multi-track Evaluation 1k tracks": "40.68ms",
+  "Schema Validation 1k actors": "298.96ms",
+  "Store Playback Updates (10k ops)": "177.72ms",
+  "Store Add Actor (1k ops)": "123.93ms",
+  "Store Update Actor (1k ops)": "1231.58ms",
+  "Store Remove Actor (1k ops)": "985.28ms"
 }


### PR DESCRIPTION
Enhanced animation engine benchmarks and recorded baseline metrics.

- Added "Easing Functions (1M ops)" benchmark to measure the performance of various easing curves.
- Added "Multi-track Evaluation (1k tracks)" benchmark using `evaluateTracksAtTime` to simulate complex scene updates.
- Scaled the "Schema Validation" benchmark to 1,000 actors for a more realistic stress test.
- Increased timeouts for store performance benchmarks to ensure stability in CI/sandbox environments.
- Updated `reports/baseline_metrics.json` with the new performance data.

---
*PR created automatically by Jules for task [2762434063926574171](https://jules.google.com/task/2762434063926574171) started by @Fredess74*