### PR TITLE
Implement License Audit Tool and Generate Report

### DIFF
--- a/docs/LICENSE_AUDIT.md
+++ b/docs/LICENSE_AUDIT.md
@@ -1,15 +1,15 @@
 # License Audit
 
-**Date:** 2026-02-25
+**Date:** 2026-05-05
 **Auditor:** Jules (License Auditor)
 
 ## Summary
 
 This document lists all dependencies used in the project and their licenses. It also flags any non-MIT licenses and checks for the presence of the project's own LICENSE file.
 
-Total dependencies found: 687
+Total dependencies found: 683
 Direct dependencies: 33
-Transitive dependencies: 654
+Transitive dependencies: 650
 
 ## Project License
 
@@ -27,10 +27,12 @@ Transitive dependencies: 654
 The following dependencies have non-MIT licenses:
 
 | Dependency | Version | License | Type |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 | Transitive |
 | @ethereumjs/rlp | 4.0.1 | MPL-2.0 | Transitive |
+| @ethereumjs/rlp | 5.0.2 | MPL-2.0 | Transitive |
 | @ethereumjs/util | 8.1.0 | MPL-2.0 | Transitive |
+| @ethereumjs/util | 9.1.0 | MPL-2.0 | Transitive |
 | @img/sharp-libvips-linux-x64 | 1.2.4 | LGPL-3.0-or-later | Transitive |
 | @img/sharp-libvips-linuxmusl-x64 | 1.2.4 | LGPL-3.0-or-later | Transitive |
 | @img/sharp-linux-x64 | 0.34.5 | Apache-2.0 | Transitive |
@@ -61,12 +63,14 @@ The following dependencies have non-MIT licenses:
 | crypt | 0.0.2 | BSD-3-Clause | Transitive |
 | detect-libc | 2.1.2 | Apache-2.0 | Transitive |
 | diff | 4.0.4 | BSD-3-Clause | Transitive |
+| diff | 5.2.2 | BSD-3-Clause | Transitive |
 | difflib | 0.2.4 | PSF | Transitive |
 | draco3d | 1.5.7 | Apache-2.0 | Transitive |
 | electron-to-chromium | 1.5.302 | ISC | Transitive |
 | entities | 6.0.1 | BSD-2-Clause | Transitive |
 | escodegen | 1.8.1 | BSD-2-Clause | Transitive |
 | esprima | 2.7.3 | BSD-2-Clause | Transitive |
+| esprima | 4.0.1 | BSD-2-Clause | Transitive |
 | estraverse | 1.9.3 | BSD | Transitive |
 | esutils | 2.0.3 | BSD-2-Clause | Transitive |
 | ethereumjs-util | 7.1.5 | MPL-2.0 | Transitive |
@@ -78,6 +82,9 @@ The following dependencies have non-MIT licenses:
 | get-caller-file | 2.0.5 | ISC | Transitive |
 | ghost-testrpc | 0.0.2 | ISC | Transitive |
 | glob | 5.0.15 | ISC | Transitive |
+| glob | 7.1.7 | ISC | Transitive |
+| glob | 7.2.3 | ISC | Transitive |
+| glob | 8.1.0 | ISC | Transitive |
 | glob-parent | 5.1.2 | ISC | Transitive |
 | graceful-fs | 4.2.11 | ISC | Transitive |
 | hls.js | 1.6.15 | Apache-2.0 | Transitive |
@@ -90,14 +97,15 @@ The following dependencies have non-MIT licenses:
 | lightningcss | 1.31.1 | MPL-2.0 | Transitive |
 | lightningcss-linux-x64-gnu | 1.31.1 | MPL-2.0 | Transitive |
 | lightningcss-linux-x64-musl | 1.31.1 | MPL-2.0 | Transitive |
-| lru-cache | 5.1.1 | ISC | Transitive |
 | lru-cache | 11.2.6 | BlueOak-1.0.0 | Transitive |
+| lru-cache | 5.1.1 | ISC | Transitive |
 | lucide-react | 0.563.0 | ISC | **Direct** |
 | make-error | 1.3.6 | ISC | Transitive |
 | mdn-data | 2.12.2 | CC0-1.0 | Transitive |
 | minimalistic-assert | 1.0.1 | ISC | Transitive |
-| minimatch | 3.1.3 | ISC | Transitive |
 | minimatch | 10.2.2 | BlueOak-1.0.0 | Transitive |
+| minimatch | 3.1.3 | ISC | Transitive |
+| minimatch | 5.1.7 | ISC | Transitive |
 | ndjson | 2.0.0 | BSD-3-Clause | Transitive |
 | nopt | 3.0.6 | ISC | Transitive |
 | once | 1.4.0 | ISC | Transitive |
@@ -110,6 +118,8 @@ The following dependencies have non-MIT licenses:
 | saxes | 6.0.0 | ISC | Transitive |
 | sc-istanbul | 0.4.6 | BSD-3-Clause | Transitive |
 | semver | 5.7.2 | ISC | Transitive |
+| semver | 6.3.1 | ISC | Transitive |
+| semver | 7.7.4 | ISC | Transitive |
 | serialize-javascript | 6.0.2 | BSD-3-Clause | Transitive |
 | setprototypeof | 1.2.0 | ISC | Transitive |
 | sha1 | 1.1.1 | BSD-3-Clause | Transitive |
@@ -117,8 +127,8 @@ The following dependencies have non-MIT licenses:
 | shelljs | 0.8.5 | BSD-3-Clause | Transitive |
 | siginfo | 2.0.0 | ISC | Transitive |
 | solidity-coverage | 0.8.17 | ISC | Transitive |
-| source-map | 0.6.1 | BSD-3-Clause | Transitive |
 | source-map | 0.2.0 | BSD | Transitive |
+| source-map | 0.6.1 | BSD-3-Clause | Transitive |
 | source-map-js | 1.2.1 | BSD-3-Clause | Transitive |
 | split2 | 3.2.2 | ISC | Transitive |
 | sprintf-js | 1.0.3 | BSD-3-Clause | Transitive |
@@ -126,11 +136,14 @@ The following dependencies have non-MIT licenses:
 | tough-cookie | 6.0.0 | BSD-3-Clause | Transitive |
 | ts-command-line-args | 2.5.1 | ISC | Transitive |
 | tslib | 1.14.1 | 0BSD | Transitive |
+| tslib | 2.7.0 | 0BSD | Transitive |
+| tslib | 2.8.1 | 0BSD | Transitive |
 | typescript | 5.9.3 | Apache-2.0 | **Direct** |
 | uglify-js | 3.19.3 | BSD-2-Clause | Transitive |
 | web3-utils | 1.10.4 | LGPL-3.0 | Transitive |
 | webidl-conversions | 8.0.1 | BSD-2-Clause | Transitive |
 | which | 1.3.1 | ISC | Transitive |
+| which | 2.0.2 | ISC | Transitive |
 | workerpool | 6.5.1 | Apache-2.0 | Transitive |
 | wrappy | 1.0.2 | ISC | Transitive |
 | xml-name-validator | 5.0.0 | Apache-2.0 | Transitive |
@@ -144,7 +157,7 @@ The following dependencies have non-MIT licenses:
 | --- | --- | --- |
 | @nomicfoundation/hardhat-toolbox | MIT | @Animatica/contracts |
 | @openzeppelin/contracts | MIT | @Animatica/contracts |
-| @react-three/drei | MIT | @Animatica/engine |
+| @react-three/drei | MIT | @Animatica/editor, @Animatica/engine |
 | @react-three/fiber | MIT | @Animatica/editor, @Animatica/engine, @Animatica/web |
 | @tailwindcss/postcss | MIT | @Animatica/editor |
 | @testing-library/dom | MIT | @Animatica/web |
@@ -152,7 +165,7 @@ The following dependencies have non-MIT licenses:
 | @types/node | MIT | @Animatica/engine |
 | @types/react | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
 | @types/react-dom | MIT | @Animatica/editor, @Animatica/platform, @Animatica/web |
-| @types/three | MIT | @Animatica/engine |
+| @types/three | MIT | @Animatica/editor, @Animatica/engine |
 | @types/uuid | MIT | @Animatica/engine |
 | @vitejs/plugin-react | MIT | @Animatica/editor |
 | clsx | MIT | @Animatica/editor |
@@ -172,7 +185,7 @@ The following dependencies have non-MIT licenses:
 | uuid | MIT | @Animatica/engine |
 | vite | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform |
 | vitest | MIT | @Animatica/editor, @Animatica/engine, @Animatica/platform, @Animatica/web |
-| zod | MIT | @Animatica/engine |
+| zod | MIT | @Animatica/engine, @Animatica/web |
 | zundo | MIT | @Animatica/engine |
 | zustand | MIT | @Animatica/engine |
 
@@ -220,11 +233,14 @@ The following dependencies have non-MIT licenses:
 | @dimforge/rapier3d-compat | 0.12.0 | Apache-2.0 |
 | @esbuild/linux-x64 | 0.27.3 | MIT |
 | @ethereumjs/rlp | 4.0.1 | MPL-2.0 |
+| @ethereumjs/rlp | 5.0.2 | MPL-2.0 |
 | @ethereumjs/util | 8.1.0 | MPL-2.0 |
+| @ethereumjs/util | 9.1.0 | MPL-2.0 |
 | @ethersproject/abi | 5.8.0 | MIT |
 | @ethersproject/abstract-provider | 5.8.0 | MIT |
 | @ethersproject/abstract-signer | 5.8.0 | MIT |
 | @ethersproject/address | 5.6.1 | MIT |
+| @ethersproject/address | 5.8.0 | MIT |
 | @ethersproject/base64 | 5.8.0 | MIT |
 | @ethersproject/basex | 5.8.0 | MIT |
 | @ethersproject/bignumber | 5.8.0 | MIT |
@@ -262,6 +278,7 @@ The following dependencies have non-MIT licenses:
 | @jridgewell/remapping | 2.3.5 | MIT |
 | @jridgewell/resolve-uri | 3.1.2 | MIT |
 | @jridgewell/sourcemap-codec | 1.5.5 | MIT |
+| @jridgewell/trace-mapping | 0.3.31 | MIT |
 | @jridgewell/trace-mapping | 0.3.9 | MIT |
 | @mediapipe/tasks-vision | 0.10.17 | Apache-2.0 |
 | @monogrid/gainmap-js | 3.4.0 | MIT |
@@ -269,7 +286,13 @@ The following dependencies have non-MIT licenses:
 | @next/swc-linux-x64-gnu | 15.5.12 | MIT |
 | @next/swc-linux-x64-musl | 15.5.12 | MIT |
 | @noble/curves | 1.2.0 | MIT |
+| @noble/curves | 1.4.2 | MIT |
+| @noble/curves | 1.8.2 | MIT |
 | @noble/hashes | 1.2.0 | MIT |
+| @noble/hashes | 1.3.2 | MIT |
+| @noble/hashes | 1.4.0 | MIT |
+| @noble/hashes | 1.7.2 | MIT |
+| @noble/hashes | 1.8.0 | MIT |
 | @noble/secp256k1 | 1.7.1 | MIT |
 | @nodelib/fs.scandir | 2.1.5 | MIT |
 | @nodelib/fs.stat | 2.0.5 | MIT |
@@ -306,8 +329,11 @@ The following dependencies have non-MIT licenses:
 | @rollup/rollup-linux-x64-gnu | 4.58.0 | MIT |
 | @rollup/rollup-linux-x64-musl | 4.58.0 | MIT |
 | @scure/base | 1.1.9 | MIT |
+| @scure/base | 1.2.6 | MIT |
 | @scure/bip32 | 1.1.5 | MIT |
+| @scure/bip32 | 1.4.0 | MIT |
 | @scure/bip39 | 1.1.1 | MIT |
+| @scure/bip39 | 1.3.0 | MIT |
 | @sentry/core | 5.30.0 | BSD-3-Clause |
 | @sentry/hub | 5.30.0 | BSD-3-Clause |
 | @sentry/minimal | 5.30.0 | BSD-3-Clause |
@@ -316,6 +342,7 @@ The following dependencies have non-MIT licenses:
 | @sentry/types | 5.30.0 | BSD-3-Clause |
 | @sentry/utils | 5.30.0 | BSD-3-Clause |
 | @solidity-parser/parser | 0.14.5 | MIT |
+| @solidity-parser/parser | 0.20.2 | MIT |
 | @standard-schema/spec | 1.1.0 | MIT |
 | @swc/helpers | 0.5.15 | Apache-2.0 |
 | @tailwindcss/node | 4.2.0 | MIT |
@@ -348,6 +375,9 @@ The following dependencies have non-MIT licenses:
 | @types/glob | 7.2.0 | MIT |
 | @types/minimatch | 6.0.0 | MIT |
 | @types/mocha | 10.0.10 | MIT |
+| @types/node | 10.17.60 | MIT |
+| @types/node | 22.7.5 | MIT |
+| @types/node | 25.3.0 | MIT |
 | @types/node | 8.10.66 | MIT |
 | @types/offscreencanvas | 2019.7.3 | MIT |
 | @types/pbkdf2 | 3.1.2 | MIT |
@@ -377,7 +407,9 @@ The following dependencies have non-MIT licenses:
 | acorn-walk | 8.3.5 | MIT |
 | adm-zip | 0.4.16 | MIT |
 | aes-js | 3.0.0 | MIT |
+| aes-js | 4.0.0-beta.5 | MIT |
 | agent-base | 6.0.2 | MIT |
+| agent-base | 7.1.4 | MIT |
 | aggregate-error | 3.1.0 | MIT |
 | ajv | 8.18.0 | MIT |
 | amdefine | 1.0.1 | BSD-3-Clause OR MIT |
@@ -385,7 +417,10 @@ The following dependencies have non-MIT licenses:
 | ansi-colors | 4.1.3 | MIT |
 | ansi-escapes | 4.3.2 | MIT |
 | ansi-regex | 3.0.1 | MIT |
+| ansi-regex | 5.0.1 | MIT |
 | ansi-styles | 3.2.1 | MIT |
+| ansi-styles | 4.3.0 | MIT |
+| ansi-styles | 5.2.0 | MIT |
 | antlr4ts | 0.5.0-alpha.4 | BSD-3-Clause |
 | anymatch | 3.1.3 | ISC |
 | arg | 4.1.3 | MIT |
@@ -393,6 +428,7 @@ The following dependencies have non-MIT licenses:
 | argparse | 2.0.1 | Python-2.0 |
 | aria-query | 5.3.0 | Apache-2.0 |
 | array-back | 3.1.0 | MIT |
+| array-back | 4.0.2 | MIT |
 | array-union | 2.1.0 | MIT |
 | array-uniq | 1.0.3 | MIT |
 | asap | 2.0.6 | MIT |
@@ -405,6 +441,7 @@ The following dependencies have non-MIT licenses:
 | available-typed-arrays | 1.0.7 | MIT |
 | axios | 1.13.5 | MIT |
 | balanced-match | 1.0.2 | MIT |
+| balanced-match | 4.0.3 | MIT |
 | base-x | 3.0.11 | MIT |
 | base64-js | 1.5.1 | MIT |
 | baseline-browser-mapping | 2.10.0 | Apache-2.0 |
@@ -413,8 +450,12 @@ The following dependencies have non-MIT licenses:
 | binary-extensions | 2.3.0 | MIT |
 | blakejs | 1.2.1 | MIT |
 | bn.js | 4.11.6 | MIT |
+| bn.js | 4.12.3 | MIT |
+| bn.js | 5.2.3 | MIT |
 | boxen | 5.1.2 | MIT |
 | brace-expansion | 1.1.12 | MIT |
+| brace-expansion | 2.0.2 | MIT |
+| brace-expansion | 5.0.2 | MIT |
 | braces | 3.0.3 | MIT |
 | brorand | 1.1.0 | MIT |
 | browser-stdout | 1.3.1 | ISC |
@@ -434,12 +475,15 @@ The following dependencies have non-MIT licenses:
 | caniuse-lite | 1.0.30001770 | CC-BY-4.0 |
 | caseless | 0.12.0 | Apache-2.0 |
 | cbor | 8.1.0 | MIT |
+| cbor | 9.0.2 | MIT |
 | chai | 6.2.2 | MIT |
 | chai-as-promised | 7.1.2 | WTFPL |
 | chalk | 2.4.2 | MIT |
+| chalk | 4.1.2 | MIT |
 | charenc | 0.0.2 | BSD-3-Clause |
 | check-error | 1.0.3 | MIT |
 | chokidar | 3.6.0 | MIT |
+| chokidar | 4.0.3 | MIT |
 | ci-info | 2.0.0 | MIT |
 | cipher-base | 1.0.7 | MIT |
 | clean-stack | 2.2.0 | MIT |
@@ -449,7 +493,9 @@ The following dependencies have non-MIT licenses:
 | cliui | 7.0.4 | ISC |
 | clsx | 2.1.1 | MIT |
 | color-convert | 1.9.3 | MIT |
+| color-convert | 2.0.1 | MIT |
 | color-name | 1.1.3 | MIT |
+| color-name | 1.1.4 | MIT |
 | colors | 1.4.0 | MIT |
 | combined-stream | 1.0.8 | MIT |
 | command-exists | 1.2.9 | MIT |
@@ -485,6 +531,7 @@ The following dependencies have non-MIT licenses:
 | detect-gpu | 5.0.70 | MIT |
 | detect-libc | 2.1.2 | Apache-2.0 |
 | diff | 4.0.4 | BSD-3-Clause |
+| diff | 5.2.2 | BSD-3-Clause |
 | difflib | 0.2.4 | PSF |
 | dir-glob | 3.0.1 | MIT |
 | dom-accessibility-api | 0.5.16 | MIT |
@@ -505,16 +552,21 @@ The following dependencies have non-MIT licenses:
 | esbuild | 0.27.3 | MIT |
 | escalade | 3.2.0 | MIT |
 | escape-string-regexp | 1.0.5 | MIT |
+| escape-string-regexp | 4.0.0 | MIT |
 | escodegen | 1.8.1 | BSD-2-Clause |
 | esprima | 2.7.3 | BSD-2-Clause |
+| esprima | 4.0.1 | BSD-2-Clause |
 | estraverse | 1.9.3 | BSD |
 | estree-walker | 3.0.3 | MIT |
 | esutils | 2.0.3 | BSD-2-Clause |
 | eth-gas-reporter | 0.2.27 | MIT |
 | ethereum-bloom-filters | 1.2.0 | MIT |
 | ethereum-cryptography | 0.1.3 | MIT |
+| ethereum-cryptography | 1.2.0 | MIT |
+| ethereum-cryptography | 2.2.1 | MIT |
 | ethereumjs-util | 7.1.5 | MPL-2.0 |
 | ethers | 5.8.0 | MIT |
+| ethers | 6.16.0 | MIT |
 | ethjs-unit | 0.1.6 | MIT |
 | evp_bytestokey | 1.0.3 | MIT |
 | expect-type | 1.3.0 | Apache-2.0 |
@@ -525,6 +577,7 @@ The following dependencies have non-MIT licenses:
 | fastq | 1.20.1 | ISC |
 | fdir | 6.5.0 | MIT |
 | fflate | 0.6.10 | MIT |
+| fflate | 0.8.2 | MIT |
 | fill-range | 7.1.1 | MIT |
 | find-replace | 3.0.0 | MIT |
 | find-up | 5.0.0 | MIT |
@@ -532,8 +585,12 @@ The following dependencies have non-MIT licenses:
 | follow-redirects | 1.15.11 | MIT |
 | for-each | 0.3.5 | MIT |
 | form-data | 2.5.5 | MIT |
+| form-data | 4.0.5 | MIT |
 | fp-ts | 1.19.3 | MIT |
+| fs-extra | 10.1.0 | MIT |
 | fs-extra | 7.0.1 | MIT |
+| fs-extra | 8.1.0 | MIT |
+| fs-extra | 9.1.0 | MIT |
 | fs-readdir-recursive | 1.1.0 | MIT |
 | fs.realpath | 1.0.0 | ISC |
 | function-bind | 1.1.2 | MIT |
@@ -545,6 +602,9 @@ The following dependencies have non-MIT licenses:
 | get-proto | 1.0.1 | MIT |
 | ghost-testrpc | 0.0.2 | ISC |
 | glob | 5.0.15 | ISC |
+| glob | 7.1.7 | ISC |
+| glob | 7.2.3 | ISC |
+| glob | 8.1.0 | ISC |
 | glob-parent | 5.1.2 | ISC |
 | global-modules | 2.0.0 | MIT |
 | global-prefix | 3.0.0 | MIT |
@@ -556,6 +616,8 @@ The following dependencies have non-MIT licenses:
 | hardhat | 2.28.6 | MIT |
 | hardhat-gas-reporter | 1.0.10 | MIT |
 | has-flag | 1.0.0 | MIT |
+| has-flag | 3.0.0 | MIT |
+| has-flag | 4.0.0 | MIT |
 | has-property-descriptors | 1.0.2 | MIT |
 | has-symbols | 1.1.0 | MIT |
 | has-tostringtag | 1.0.2 | MIT |
@@ -572,11 +634,13 @@ The following dependencies have non-MIT licenses:
 | http-proxy-agent | 7.0.2 | MIT |
 | http-response-object | 3.0.2 | MIT |
 | https-proxy-agent | 5.0.1 | MIT |
+| https-proxy-agent | 7.0.6 | MIT |
 | iconv-lite | 0.4.24 | MIT |
 | ieee754 | 1.2.1 | BSD-3-Clause |
 | ignore | 5.3.2 | MIT |
 | immediate | 3.0.6 | MIT |
 | immer | 10.0.2 | MIT |
+| immer | 10.2.0 | MIT |
 | immutable | 4.3.7 | MIT |
 | indent-string | 4.0.0 | MIT |
 | inflight | 1.0.6 | ISC |
@@ -589,6 +653,7 @@ The following dependencies have non-MIT licenses:
 | is-core-module | 2.16.1 | MIT |
 | is-extglob | 2.1.1 | MIT |
 | is-fullwidth-code-point | 2.0.0 | MIT |
+| is-fullwidth-code-point | 3.0.0 | MIT |
 | is-glob | 4.0.3 | MIT |
 | is-hex-prefixed | 1.0.0 | MIT |
 | is-number | 7.0.0 | MIT |
@@ -598,12 +663,14 @@ The following dependencies have non-MIT licenses:
 | is-typed-array | 1.1.15 | MIT |
 | is-unicode-supported | 0.1.0 | MIT |
 | isarray | 1.0.0 | MIT |
+| isarray | 2.0.5 | MIT |
 | isexe | 2.0.0 | ISC |
 | its-fine | 2.0.0 | MIT |
 | jiti | 2.6.1 | MIT |
 | js-sha3 | 0.8.0 | MIT |
 | js-tokens | 4.0.0 | MIT |
 | js-yaml | 3.14.2 | MIT |
+| js-yaml | 4.1.1 | MIT |
 | jsdom | 28.1.0 | MIT |
 | jsesc | 3.1.0 | MIT |
 | json-schema-traverse | 1.0.0 | MIT |
@@ -611,6 +678,7 @@ The following dependencies have non-MIT licenses:
 | json-stringify-safe | 5.0.1 | ISC |
 | json5 | 2.2.3 | MIT |
 | jsonfile | 4.0.0 | MIT |
+| jsonfile | 6.2.0 | MIT |
 | jsonschema | 1.5.0 | MIT |
 | keccak | 3.0.4 | MIT |
 | kind-of | 6.0.3 | MIT |
@@ -622,14 +690,15 @@ The following dependencies have non-MIT licenses:
 | lightningcss-linux-x64-musl | 1.31.1 | MPL-2.0 |
 | locate-path | 6.0.0 | MIT |
 | lodash | 4.17.21 | MIT |
+| lodash | 4.17.23 | MIT |
 | lodash.camelcase | 4.3.0 | MIT |
 | lodash.clonedeep | 4.5.0 | MIT |
 | lodash.isequal | 4.5.0 | MIT |
 | lodash.truncate | 4.4.2 | MIT |
 | log-symbols | 4.1.0 | MIT |
-| lru_map | 0.3.3 | MIT |
-| lru-cache | 5.1.1 | ISC |
 | lru-cache | 11.2.6 | BlueOak-1.0.0 |
+| lru-cache | 5.1.1 | ISC |
+| lru_map | 0.3.3 | MIT |
 | lucide-react | 0.563.0 | ISC |
 | lz-string | 1.5.0 | MIT |
 | maath | 0.10.8 | MIT |
@@ -651,10 +720,12 @@ The following dependencies have non-MIT licenses:
 | mime-types | 2.1.35 | MIT |
 | minimalistic-assert | 1.0.1 | ISC |
 | minimalistic-crypto-utils | 1.0.1 | MIT |
-| minimatch | 3.1.3 | ISC |
 | minimatch | 10.2.2 | BlueOak-1.0.0 |
+| minimatch | 3.1.3 | ISC |
+| minimatch | 5.1.7 | ISC |
 | minimist | 1.2.8 | MIT |
 | mkdirp | 0.5.6 | MIT |
+| mkdirp | 1.0.4 | MIT |
 | mnemonist | 0.38.5 | MIT |
 | mocha | 10.8.2 | MIT |
 | ms | 2.1.3 | MIT |
@@ -663,6 +734,7 @@ The following dependencies have non-MIT licenses:
 | neo-async | 2.6.2 | MIT |
 | next | 15.5.12 | MIT |
 | node-addon-api | 2.0.2 | MIT |
+| node-addon-api | 5.1.0 | MIT |
 | node-emoji | 1.11.0 | MIT |
 | node-gyp-build | 4.8.4 | MIT |
 | node-releases | 2.0.27 | MIT |
@@ -692,9 +764,11 @@ The following dependencies have non-MIT licenses:
 | pbkdf2 | 3.1.5 | MIT |
 | picocolors | 1.1.1 | ISC |
 | picomatch | 2.3.1 | MIT |
+| picomatch | 4.0.3 | MIT |
 | pify | 4.0.1 | MIT |
 | possible-typed-array-names | 1.1.0 | MIT |
 | postcss | 8.4.31 | MIT |
+| postcss | 8.5.6 | MIT |
 | potpack | 1.0.2 | ISC |
 | prelude-ls | 1.1.2 | MIT |
 | prettier | 2.8.8 | MIT |
@@ -715,7 +789,9 @@ The following dependencies have non-MIT licenses:
 | react-refresh | 0.18.0 | MIT |
 | react-use-measure | 2.1.7 | MIT |
 | readable-stream | 2.3.8 | MIT |
+| readable-stream | 3.6.2 | MIT |
 | readdirp | 3.6.0 | MIT |
+| readdirp | 4.1.2 | MIT |
 | rechoir | 0.6.2 | MIT |
 | recursive-readdir | 2.2.3 | MIT |
 | reduce-flatten | 2.0.0 | MIT |
@@ -724,6 +800,8 @@ The following dependencies have non-MIT licenses:
 | require-directory | 2.1.1 | MIT |
 | require-from-string | 2.0.2 | MIT |
 | resolve | 1.1.7 | MIT |
+| resolve | 1.17.0 | MIT |
+| resolve | 1.22.11 | MIT |
 | resolve-from | 3.0.0 | MIT |
 | reusify | 1.1.0 | MIT |
 | ripemd160 | 2.0.3 | MIT |
@@ -731,6 +809,7 @@ The following dependencies have non-MIT licenses:
 | rollup | 4.58.0 | MIT |
 | run-parallel | 1.2.0 | MIT |
 | safe-buffer | 5.1.2 | MIT |
+| safe-buffer | 5.2.1 | MIT |
 | safer-buffer | 2.1.2 | MIT |
 | saxes | 6.0.0 | ISC |
 | sc-istanbul | 0.4.6 | BSD-3-Clause |
@@ -738,6 +817,8 @@ The following dependencies have non-MIT licenses:
 | scrypt-js | 3.0.1 | MIT |
 | secp256k1 | 4.0.4 | MIT |
 | semver | 5.7.2 | ISC |
+| semver | 6.3.1 | ISC |
+| semver | 7.7.4 | ISC |
 | serialize-javascript | 6.0.2 | BSD-3-Clause |
 | set-function-length | 1.2.2 | MIT |
 | setimmediate | 1.0.5 | MIT |
@@ -758,8 +839,8 @@ The following dependencies have non-MIT licenses:
 | slice-ansi | 4.0.0 | MIT |
 | solc | 0.8.26 | MIT |
 | solidity-coverage | 0.8.17 | ISC |
-| source-map | 0.6.1 | BSD-3-Clause |
 | source-map | 0.2.0 | BSD |
+| source-map | 0.6.1 | BSD-3-Clause |
 | source-map-js | 1.2.1 | BSD-3-Clause |
 | source-map-support | 0.5.21 | MIT |
 | split2 | 3.2.2 | ISC |
@@ -771,14 +852,20 @@ The following dependencies have non-MIT licenses:
 | stats.js | 0.17.0 | MIT |
 | statuses | 2.0.2 | MIT |
 | std-env | 3.10.0 | MIT |
-| string_decoder | 1.1.1 | MIT |
 | string-format | 2.0.0 | WTFPL OR MIT |
 | string-width | 2.1.1 | MIT |
+| string-width | 4.2.3 | MIT |
+| string_decoder | 1.1.1 | MIT |
+| string_decoder | 1.3.0 | MIT |
 | strip-ansi | 4.0.0 | MIT |
+| strip-ansi | 6.0.1 | MIT |
 | strip-hex-prefix | 1.0.0 | MIT |
 | strip-json-comments | 3.1.1 | MIT |
 | styled-jsx | 5.1.6 | MIT |
 | supports-color | 3.2.3 | MIT |
+| supports-color | 5.5.0 | MIT |
+| supports-color | 7.2.0 | MIT |
+| supports-color | 8.1.1 | MIT |
 | supports-preserve-symlinks-flag | 1.0.0 | MIT |
 | suspend-react | 0.1.3 | MIT |
 | symbol-tree | 3.2.4 | MIT |
@@ -814,28 +901,37 @@ The following dependencies have non-MIT licenses:
 | ts-essentials | 7.0.3 | MIT |
 | ts-node | 10.9.2 | MIT |
 | tslib | 1.14.1 | 0BSD |
+| tslib | 2.7.0 | 0BSD |
+| tslib | 2.8.1 | 0BSD |
 | tsort | 0.0.1 | MIT |
 | tunnel-rat | 0.1.2 | MIT |
 | turbo | 2.8.10 | MIT |
 | turbo-linux-64 | 2.8.10 | MIT |
 | type-check | 0.3.2 | MIT |
 | type-detect | 4.1.0 | MIT |
+| type-fest | 0.20.2 | (MIT OR CC0-1.0) |
+| type-fest | 0.21.3 | (MIT OR CC0-1.0) |
 | type-fest | 0.7.1 | (MIT OR CC0-1.0) |
 | typechain | 8.3.2 | MIT |
 | typed-array-buffer | 1.0.3 | MIT |
 | typedarray | 0.0.6 | MIT |
 | typescript | 5.9.3 | Apache-2.0 |
 | typical | 4.0.0 | MIT |
+| typical | 5.2.0 | MIT |
 | uglify-js | 3.19.3 | BSD-2-Clause |
 | undici | 5.29.0 | MIT |
+| undici | 7.22.0 | MIT |
 | undici-types | 6.19.8 | MIT |
+| undici-types | 7.18.2 | MIT |
 | universalify | 0.1.2 | MIT |
+| universalify | 2.0.1 | MIT |
 | unpipe | 1.0.0 | MIT |
 | update-browserslist-db | 1.2.3 | MIT |
 | use-sync-external-store | 1.6.0 | MIT |
 | utf8 | 3.0.0 | MIT |
 | util-deprecate | 1.0.2 | MIT |
 | utility-types | 3.11.0 | MIT |
+| uuid | 13.0.0 | MIT |
 | uuid | 8.3.2 | MIT |
 | v8-compile-cache-lib | 3.0.1 | MIT |
 | vite | 7.3.1 | MIT |
@@ -848,6 +944,7 @@ The following dependencies have non-MIT licenses:
 | whatwg-mimetype | 5.0.0 | MIT |
 | whatwg-url | 16.0.1 | MIT |
 | which | 1.3.1 | ISC |
+| which | 2.0.2 | ISC |
 | which-typed-array | 1.1.20 | MIT |
 | why-is-node-running | 2.3.0 | MIT |
 | widest-line | 3.1.0 | MIT |
@@ -858,6 +955,8 @@ The following dependencies have non-MIT licenses:
 | wrap-ansi | 7.0.0 | MIT |
 | wrappy | 1.0.2 | ISC |
 | ws | 7.5.10 | MIT |
+| ws | 8.17.1 | MIT |
+| ws | 8.18.0 | MIT |
 | xml-name-validator | 5.0.0 | Apache-2.0 |
 | xmlchars | 2.2.0 | MIT |
 | y18n | 5.0.8 | ISC |
@@ -867,8 +966,10 @@ The following dependencies have non-MIT licenses:
 | yargs-unparser | 2.0.0 | MIT |
 | yn | 3.1.1 | MIT |
 | yocto-queue | 0.1.0 | MIT |
+| zod | 3.25.76 | MIT |
 | zod | 4.3.6 | MIT |
 | zundo | 2.3.0 | MIT |
 | zustand | 4.5.7 | MIT |
+| zustand | 5.0.11 | MIT |
 
 </details>

--- a/scripts/audit-licenses.js
+++ b/scripts/audit-licenses.js
@@ -1,105 +1,158 @@
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
 function getPackageJsons() {
     const output = execSync('find . -name "package.json" -not -path "*/node_modules/*"').toString();
     return output.split('\n').filter(p => p.trim() !== '');
 }
 
-function loadLicenses() {
-    console.log('Running pnpm licenses list --json...');
-    const output = execSync('pnpm licenses list --json', { maxBuffer: 20 * 1024 * 1024 }).toString();
-    const data = JSON.parse(output);
+function loadLicenseData() {
+    let data;
+    if (fs.existsSync('licenses.json')) {
+        data = JSON.parse(fs.readFileSync('licenses.json', 'utf8'));
+    } else {
+        console.log('Running pnpm licenses list --json...');
+        const output = execSync('pnpm licenses list --json', { maxBuffer: 20 * 1024 * 1024 }).toString();
+        data = JSON.parse(output);
+    }
 
-    const pkgToLicense = {};
+    const pkgToInfo = {};
     for (const [licenseName, packages] of Object.entries(data)) {
         for (const pkg of packages) {
-            pkgToLicense[pkg.name] = licenseName;
+            if (!pkgToInfo[pkg.name]) {
+                pkgToInfo[pkg.name] = [];
+            }
+            // A package might have multiple versions under the same license or different licenses
+            for (const version of pkg.versions) {
+                pkgToInfo[pkg.name].push({
+                    version: version,
+                    license: licenseName
+                });
+            }
         }
     }
-    return pkgToLicense;
+    return pkgToInfo;
 }
 
 function main() {
-    const pkgToLicense = loadLicenses();
+    const pkgToInfo = loadLicenseData();
+    const directDeps = {};
+    const allDirectNames = new Set();
 
-    const allDeps = {};
-
-    for (const pjPath of getPackageJsons()) {
+    const packageJsonPaths = getPackageJsons();
+    for (const pjPath of packageJsonPaths) {
         const pj = JSON.parse(fs.readFileSync(pjPath, 'utf8'));
+        const pkgName = pj.name || 'Animatica (root)';
 
-        const deps = pj.dependencies || {};
-        const devDeps = pj.devDependencies || {};
-        const peerDeps = pj.peerDependencies || {};
+        const deps = { ...(pj.dependencies || {}), ...(pj.devDependencies || {}), ...(pj.peerDependencies || {}) };
 
-        for (const [name, version] of Object.entries({ ...deps, ...devDeps, ...peerDeps })) {
+        for (const [name, version] of Object.entries(deps)) {
             if (name.startsWith('@Animatica/') || (typeof version === 'string' && version.startsWith('workspace:'))) {
                 continue;
             }
-            if (!allDeps[name]) {
-                allDeps[name] = new Set();
+            if (!directDeps[name]) {
+                directDeps[name] = new Set();
             }
-            allDeps[name].add(pj.name || 'root');
+            directDeps[name].add(pkgName);
+            allDirectNames.add(name);
         }
     }
 
-    const sortedDeps = Object.keys(allDeps).sort();
-
-    let table = "| Dependency | License | Flag | Used In |\n";
-    table += "| --- | --- | --- | --- |\n";
-
+    const allPkgNames = Object.keys(pkgToInfo).sort();
     const flagged = [];
+    const directTable = [];
+    const allTable = [];
 
-    for (const dep of sortedDeps) {
-        const license = pkgToLicense[dep] || 'Unknown';
-        let flag = "";
-        if (license !== 'MIT' && !license.includes('MIT')) {
-            flag = "⚠️ Non-MIT";
-            flagged.push(`- **\`${dep}\`**: ${license}`);
+    let totalDeps = 0;
+    const uniquePkgNames = new Set();
+
+    for (const name of allPkgNames) {
+        const infos = pkgToInfo[name];
+        uniquePkgNames.add(name);
+        for (const info of infos) {
+            totalDeps++;
+            const isDirect = allDirectNames.has(name);
+            const license = info.license;
+            const isNonMit = license !== 'MIT' && !license.includes('MIT');
+
+            if (isNonMit) {
+                flagged.push(`| ${name} | ${info.version} | ${license} | ${isDirect ? '**Direct**' : 'Transitive'} |`);
+            }
+
+            if (isDirect) {
+                // For direct deps table, we just list the name and license (might have multiple versions but usually one is direct)
+                // To keep it simple, we'll just add it once per name/license combo if it's direct
+            }
+
+            allTable.push(`| ${name} | ${info.version} | ${license} |`);
         }
 
-        const usedIn = Array.from(allDeps[dep]).sort().join(', ');
-        table += `| ${dep} | ${license} | ${flag} | ${usedIn} |\n`;
+        if (allDirectNames.has(name)) {
+            // Get unique licenses for this direct dep
+            const licenses = Array.from(new Set(infos.map(i => i.license))).sort().join(', ');
+            const usedIn = Array.from(directDeps[name]).sort().join(', ');
+            directTable.push(`| ${name} | ${licenses} | ${usedIn} |`);
+        }
     }
 
-    const auditPath = path.join(process.cwd(), 'docs/LICENSE_AUDIT.md');
-    let auditContent = fs.readFileSync(auditPath, 'utf8');
+    let directCount = allDirectNames.size;
+    let transitiveCount = uniquePkgNames.size - directCount;
 
-    // Update Dependency Licenses section
-    // Look for the table or the header
-    const depSectionStart = "## Dependency Licenses\n\nThe following dependencies were audited:\n\n";
-    const depSectionEnd = "\n\n## Flagged Licenses";
-
-    const startIndex = auditContent.indexOf(depSectionStart);
-    const endIndex = auditContent.indexOf(depSectionEnd);
-
-    if (startIndex !== -1 && endIndex !== -1) {
-        auditContent = auditContent.substring(0, startIndex + depSectionStart.length) +
-                       table +
-                       auditContent.substring(endIndex);
-    }
-
-    // Update Flagged Licenses section
-    const flaggedSectionStart = "## Flagged Licenses (Non-MIT/Apache-2.0)\n\n";
-    const flaggedSectionEnd = "\n\n## Missing Licenses";
-
-    const fStartIndex = auditContent.indexOf(flaggedSectionStart);
-    const fEndIndex = auditContent.indexOf(flaggedSectionEnd);
-
-    if (fStartIndex !== -1 && fEndIndex !== -1) {
-        auditContent = auditContent.substring(0, fStartIndex + flaggedSectionStart.length) +
-                       flagged.join('\n') +
-                       auditContent.substring(fEndIndex);
-    }
-
-    // Update Date
-    const dateRegex = /\*\*Date:\*\* .*/;
     const today = new Date().toISOString().split('T')[0];
-    auditContent = auditContent.replace(dateRegex, `**Date:** ${today}`);
 
-    fs.writeFileSync(auditPath, auditContent);
-    console.log('Audit report updated in docs/LICENSE_AUDIT.md');
+    let content = `# License Audit
+
+**Date:** ${today}
+**Auditor:** Jules (License Auditor)
+
+## Summary
+
+This document lists all dependencies used in the project and their licenses. It also flags any non-MIT licenses and checks for the presence of the project's own LICENSE file.
+
+Total dependencies found: ${uniquePkgNames.size}
+Direct dependencies: ${directCount}
+Transitive dependencies: ${transitiveCount}
+
+## Project License
+
+- **File:** \`LICENSE\`
+- **Status:** Present
+- **License:** MIT
+
+## Source Code Headers
+
+- **Checked:** \`packages/engine/src/index.ts\`
+- **Result:** No license header found.
+
+## Flagged Licenses (Non-MIT)
+
+The following dependencies have non-MIT licenses:
+
+| Dependency | Version | License | Type |
+| --- | --- | --- | --- |
+${flagged.sort().join('\n')}
+
+## Direct Dependencies
+
+| Dependency | License | Used In |
+| --- | --- | --- |
+${directTable.sort().join('\n')}
+
+## All Dependencies (including transitive)
+
+<details>
+<summary>Click to expand full dependency list</summary>
+
+| Dependency | Version | License |
+| --- | --- | --- |
+${allTable.sort().join('\n')}
+
+</details>
+`;
+
+    fs.writeFileSync('docs/LICENSE_AUDIT.md', content);
+    console.log('Audit report generated in docs/LICENSE_AUDIT.md');
 }
 
 main();


### PR DESCRIPTION
Implemented a robust license auditing script in `scripts/audit-licenses.js` that uses `pnpm licenses list --json` to scan all dependencies. The script cross-references data with all workspace `package.json` files to distinguish between direct and transitive dependencies. Generated a comprehensive `docs/LICENSE_AUDIT.md` report which includes a summary of findings, flags all non-MIT licenses, and provides a full list of all project dependencies and their associated licenses. Corrected an issue where multiple versions/licenses for the same package were not being fully captured. Verified that core engine tests and benchmarks pass after these documentation-related changes.

---
*PR created automatically by Jules for task [18015523457275741109](https://jules.google.com/task/18015523457275741109) started by @Fredess74*