### PR TITLE
Bundle Size Audit - 2026-05-05

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-05
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | 0K | First Load JS (Stable) |
+| **@Animatica/engine** | 133K | +62K | Includes index.js (77K) and index.cjs (56K) |
+| **@Animatica/editor** | 3.4M | +3.32M | Significant growth; index.js (2.1M), index.cjs (1.3M) |
+| **@Animatica/platform** | 0.17K | -0.03K | Minimal exports |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.54M** (excluding web), **3.64M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4M)
+- `dist/index.js`: 2.1M
+- `dist/index.cjs`: 1.3M
+*Note: Large size due to inclusion of many UI components and dependencies.*
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (133K)
+- `dist/index.js`: 77K
+- `dist/index.cjs`: 56K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-05.
+- `@Animatica/editor` has grown significantly (from 76K to 3.4M) as many features (panels, viewport components) have been added.
+- `@Animatica/engine` size has nearly doubled (from 71K to 133K).
+- `@Animatica/web` First Load JS remains stable at 102K.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Investigate tree-shaking and externalizing more dependencies. The 2.1M `index.js` is quite large for a library. Check if `@react-three/drei` or other heavy dependencies are being bundled.
+- **@Animatica/engine**: Monitor growth as R3F renderers and animation logic are expanded.
+- **@Animatica/web**: Continue monitoring as more pages are added.


### PR DESCRIPTION
Performed a bundle size audit of all packages and applications. Updated `docs/BUNDLE_REPORT.md` with the latest measurements, including detailed breakdowns and comparisons to previous benchmarks. Noted significant size increases in the editor and engine packages.

---
*PR created automatically by Jules for task [1935353797975052261](https://jules.google.com/task/1935353797975052261) started by @Fredess74*