### PR TITLE
feat(engine): implement manual bone control for character posing

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+  let bones: Map<string, THREE.Bone>
+  let controller: BoneController
+
+  beforeEach(() => {
+    bones = new Map()
+    const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+    boneNames.forEach((name) => {
+      const bone = new THREE.Bone()
+      bone.name = name
+      bones.set(name, bone)
+    })
+    controller = new BoneController(bones)
+  })
+
+  it('should initialize correctly', () => {
+    expect(controller).toBeDefined()
+  })
+
+  it('should set target rotations from BodyPose', () => {
+    const pose: BodyPose = {
+      head: [0.1, 0.2, 0.3],
+      spine: [0.4, 0.5, 0.6],
+    }
+    controller.setPose(pose)
+
+    // Internally targets are private, but we can verify by calling update
+    controller.update(1.0) // Large delta should bring it very close to target
+
+    const head = bones.get('Head')!
+    const expectedHeadQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(0.1, 0.2, 0.3))
+    expect(head.quaternion.x).toBeCloseTo(expectedHeadQuat.x)
+    expect(head.quaternion.y).toBeCloseTo(expectedHeadQuat.y)
+    expect(head.quaternion.z).toBeCloseTo(expectedHeadQuat.z)
+    expect(head.quaternion.w).toBeCloseTo(expectedHeadQuat.w)
+  })
+
+  it('should smoothly interpolate over multiple updates', () => {
+    const pose: BodyPose = {
+      head: [Math.PI / 2, 0, 0],
+    }
+    controller.setPose(pose)
+
+    const head = bones.get('Head')!
+
+    // First update with small delta
+    controller.update(0.01)
+    expect(head.quaternion.x).toBeGreaterThan(0)
+    expect(head.quaternion.x).toBeLessThan(new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)).x)
+
+    // Second update with large delta
+    controller.update(1.0)
+    const expectedQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0))
+    expect(head.quaternion.x).toBeCloseTo(expectedQuat.x)
+  })
+
+  it('should snap to pose immediately', () => {
+    const pose: BodyPose = {
+      leftArm: [0, 1, 0],
+    }
+    controller.snapToPose(pose)
+
+    const leftArm = bones.get('LeftArm')!
+    const expectedQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 1, 0))
+    expect(leftArm.quaternion.y).toBeCloseTo(expectedQuat.y)
+  })
+
+  it('should reset all bones', () => {
+    const pose: BodyPose = {
+      head: [1, 1, 1],
+    }
+    controller.snapToPose(pose)
+    controller.reset()
+
+    bones.forEach((bone) => {
+      expect(bone.quaternion.x).toBe(0)
+      expect(bone.quaternion.y).toBe(0)
+      expect(bone.quaternion.z).toBe(0)
+      expect(bone.quaternion.w).toBe(1)
+    })
+  })
+
+  it('should handle missing bones gracefully', () => {
+    const emptyBones = new Map<string, THREE.Bone>()
+    const partialController = new BoneController(emptyBones)
+
+    const pose: BodyPose = {
+      head: [1, 1, 1],
+    }
+
+    expect(() => {
+      partialController.setPose(pose)
+      partialController.update(0.1)
+    }).not.toThrow()
+  })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three'
+import { BodyPose, Vector3 } from '../types'
+
+/**
+ * Maps BodyPose properties to actual humanoid bone names.
+ */
+const BONE_MAP: Record<keyof BodyPose, string> = {
+  head: 'Head',
+  spine: 'Spine',
+  leftArm: 'LeftArm',
+  rightArm: 'RightArm',
+  leftLeg: 'LeftUpperLeg',
+  rightLeg: 'RightUpperLeg',
+}
+
+/**
+ * BoneController — Handles manual character posing via BodyPose data.
+ * Applies smooth interpolation to bone rotations for frame-rate independence.
+ */
+export class BoneController {
+  private bones: Map<string, THREE.Bone>
+  private targets: Map<string, THREE.Quaternion> = new Map()
+  private speed: number = 10.0
+
+  constructor(bones: Map<string, THREE.Bone>) {
+    this.bones = bones
+  }
+
+  /**
+   * Update the target pose. Values will be interpolated in the next update() calls.
+   */
+  setPose(pose: BodyPose): void {
+    for (const [key, boneName] of Object.entries(BONE_MAP)) {
+      const rotation = pose[key as keyof BodyPose] as Vector3 | undefined
+      if (rotation) {
+        const quat = new THREE.Quaternion().setFromEuler(
+          new THREE.Euler(rotation[0], rotation[1], rotation[2])
+        )
+        this.targets.set(boneName, quat)
+      }
+    }
+  }
+
+  /**
+   * Set interpolation speed.
+   */
+  setSpeed(speed: number): void {
+    this.speed = speed
+  }
+
+  /**
+   * Apply interpolation to bones. Call this every frame.
+   */
+  update(delta: number): void {
+    if (delta <= 0) return
+
+    const alpha = 1 - Math.exp(-this.speed * delta)
+
+    this.targets.forEach((targetQuat, boneName) => {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        bone.quaternion.slerp(targetQuat, alpha)
+      }
+    })
+  }
+
+  /**
+   * Immediately snap bones to the target pose.
+   */
+  snapToPose(pose: BodyPose): void {
+    this.setPose(pose)
+    this.targets.forEach((targetQuat, boneName) => {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        bone.quaternion.copy(targetQuat)
+      }
+    })
+  }
+
+  /**
+   * Reset all bones in the controller to their default (identity) rotation.
+   */
+  reset(): void {
+    this.targets.clear()
+    Object.values(BONE_MAP).forEach((boneName) => {
+      const bone = this.bones.get(boneName)
+      if (bone) {
+        bone.quaternion.set(0, 0, 0, 1)
+      }
+    })
+  }
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -8,6 +8,8 @@ export type { CharacterRig, HumanoidBoneName } from './CharacterLoader'
 export { CharacterAnimator, createIdleClip, createWalkClip, createRunClip, createTalkClip, createWaveClip, createDanceClip, createSitClip, createJumpClip } from './CharacterAnimator'
 export type { AnimState, AnimationTransition } from './CharacterAnimator'
 
+export { BoneController } from './BoneController'
+
 export { FaceMorphController, BLEND_SHAPES, EXPRESSION_PRESETS, VISEME_MAP } from './FaceMorphController'
 export type { BlendShapeName, BlendShapeValues } from './FaceMorphController'
 

--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import React from 'react'
-// @ts-ignore
+import * as THREE from 'three'
 import { CharacterRenderer } from './CharacterRenderer'
 import { CharacterActor } from '../../types'
 
@@ -9,11 +9,19 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
     ...actual,
-    useRef: () => ({ current: null }),
+    useRef: vi.fn(() => ({ current: null })),
+    useMemo: vi.fn((fn) => fn()),
+    useEffect: vi.fn(),
+    memo: vi.fn((c) => c),
   }
 })
 
-// Mock the Edges component from @react-three/drei
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
+
+// Mock @react-three/drei
 vi.mock('@react-three/drei', () => ({
   Edges: () => null
 }))
@@ -39,11 +47,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders a group containing primitive rig with correct transform', () => {
+    // Call the component function directly
+    const result = (CharacterRenderer as any)({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +62,29 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Should contain a primitive object (the rig)
+    const rigPrimitive = children.find(child => child.type === 'primitive')
+    expect(rigPrimitive).toBeDefined()
+    expect((rigPrimitive?.props as any).object).toBeInstanceOf(THREE.Group)
   })
 
-  it('renders nothing when visible is false', () => {
+  it('sets visibility on the group', () => {
     const invisibleActor = { ...mockActor, visible: false }
-    // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
-    expect(result).toBeNull()
+    const result = (CharacterRenderer as any)({ actor: invisibleActor }) as React.ReactElement
+    expect(result.props.visible).toBe(false)
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection indicator when selected', () => {
+    const result = (CharacterRenderer as any)({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Should have a selection ring (mesh with ringGeometry)
+    const selectionRing = children.find(child => {
+        if (child.type !== 'mesh') return false
+        const meshChildren = React.Children.toArray(child.props.children)
+        return meshChildren.some(c => (c as any).type === 'ringGeometry')
+    })
+    expect(selectionRing).toBeDefined()
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -2,7 +2,7 @@
  * CharacterRenderer — R3F component for rendering a character actor.
  * Creates a procedural humanoid (or loads GLB), applies animation, face morphs, and eye tracking.
  */
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, memo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { createProceduralHumanoid } from '../../character/CharacterLoader'
@@ -17,6 +17,7 @@ import {
   createWalkClip,
   createWaveClip,
 } from '../../character/CharacterAnimator'
+import { BoneController } from '../../character/BoneController'
 import { FaceMorphController } from '../../character/FaceMorphController'
 import { EyeController } from '../../character/EyeController'
 import { getPreset } from '../../character/CharacterPresets'
@@ -28,13 +29,14 @@ interface CharacterRendererProps {
   onClick?: () => void
 }
 
-export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
+export const CharacterRenderer: React.FC<CharacterRendererProps> = memo(({
   actor,
   isSelected = false,
   onClick,
 }) => {
   const groupRef = useRef<THREE.Group>(null)
   const animatorRef = useRef<CharacterAnimator | null>(null)
+  const boneControllerRef = useRef<BoneController | null>(null)
   const faceMorphRef = useRef<FaceMorphController | null>(null)
   const eyeControllerRef = useRef<EyeController | null>(null)
 
@@ -64,6 +66,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     animator.play(actor.animation || 'idle')
     animatorRef.current = animator
 
+    // Setup bone controller
+    const boneController = new BoneController(rig.bones)
+    if (actor.bodyPose) {
+      boneController.snapToPose(actor.bodyPose as any)
+    }
+    boneControllerRef.current = boneController
+
     // Setup face morph controller
     const faceMorph = new FaceMorphController(rig.bodyMesh, rig.morphTargetMap)
     faceMorphRef.current = faceMorph
@@ -91,6 +100,13 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [actor.animationSpeed])
 
+  // React to body pose changes
+  useEffect(() => {
+    if (boneControllerRef.current && actor.bodyPose) {
+      boneControllerRef.current.setPose(actor.bodyPose as any)
+    }
+  }, [actor.bodyPose])
+
   // React to morph target / expression changes from CharacterPanel
   useEffect(() => {
     if (faceMorphRef.current && actor.morphTargets) {
@@ -103,6 +119,11 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
+    }
+
+    // Manual body pose overrides
+    if (boneControllerRef.current) {
+      boneControllerRef.current.update(delta)
     }
 
     // Face morph blending
@@ -151,4 +172,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       )}
     </group>
   )
-}
+})
+
+CharacterRenderer.displayName = 'CharacterRenderer'


### PR DESCRIPTION
This PR implements the BoneController to allow manual character posing via the BodyPose data model. It integrates this controller into the CharacterRenderer, enabling smooth interpolation of bone rotations. It also includes unit tests for the BoneController and updates CharacterRenderer tests to reflect the new rig-based rendering.

---
*PR created automatically by Jules for task [8462256134472069598](https://jules.google.com/task/8462256134472069598) started by @Fredess74*