### PR TITLE
Bundle Size Audit - May 9, 2026

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-09
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | 0K | First Load JS (stable) |
+| **@Animatica/engine** | 135.4K | +64.4K | Significant growth (index.js: 77K, index.cjs: 56K) |
+| **@Animatica/editor** | 3.4M | +3.3M | REGRESSION: `three` and R3F are being bundled |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.5M** (excluding web), **3.6M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.4M)
+- `dist/index.js`: 2.1M
+- `dist/index.cjs`: 1.3M
+- Note: Vite config needs to externalize `three` and `@react-three/fiber`.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 77K
+- `dist/index.cjs`: 56K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-09.
+- `@Animatica/engine` size increased due to additional core logic and types.
+- **CRITICAL**: `@Animatica/editor` has experienced a massive size regression (from 76K to 3.4M). This is because `three` and `@react-three/fiber` are being bundled into the package instead of being treated as external dependencies.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Fix `vite.config.ts` to externalize `three`, `@react-three/fiber`, and `@react-three/drei`.
+- **@Animatica/engine**: Continue monitoring size; current growth is acceptable given feature additions.
+- **@Animatica/web**: First Load JS remains stable at 102K.


### PR DESCRIPTION
Performed a full bundle size audit of the Animatica project.

### Findings:
- **@Animatica/web**: 102K (Stable)
- **@Animatica/engine**: 135.4K (Increased due to features)
- **@Animatica/editor**: 3.4M (**REGRESSION**)
- **@Animatica/platform**: 0.2K
- **@Animatica/contracts**: 8K (Cache)

The regression in `@Animatica/editor` is caused by `three` and `@react-three/fiber` being bundled into the package distribution. A fix for `vite.config.ts` to externalize these dependencies is recommended.

This PR only includes the updated report in `docs/BUNDLE_REPORT.md`.

---
*PR created automatically by Jules for task [3153942566543040119](https://jules.google.com/task/3153942566543040119) started by @Fredess74*