### PR TITLE
fix(engine): standardise selection colors and optimize character renderer

### DIFF
--- a/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.test.tsx
@@ -10,8 +10,20 @@ vi.mock('react', async () => {
   return {
     ...actual,
     useRef: () => ({ current: null }),
+    useMemo: (fn: any) => fn(),
+    useEffect: () => {},
+    memo: (fn: any) => {
+      const component = (props: any) => fn(props)
+      component.type = { render: fn }
+      return component
+    }
   }
 })
+
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn(),
+}))
 
 // Mock the Edges component from @react-three/drei
 vi.mock('@react-three/drei', () => ({
@@ -39,11 +51,9 @@ describe('CharacterRenderer', () => {
     clothing: {}
   }
 
-  it('renders a group containing capsule mesh with correct transform', () => {
-    // Call the forwardRef component's render function directly
-    // Since it's wrapped in memo, we access the underlying forwardRef via .type
+  it('renders a group containing character rig with correct transform', () => {
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+    const result = CharacterRenderer.type.render({ actor: mockActor }) as React.ReactElement
 
     expect(result).not.toBeNull()
     expect(result.type).toBe('group')
@@ -56,47 +66,31 @@ describe('CharacterRenderer', () => {
     // Verify children
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // First child should be the main mesh (capsule)
-    const mainMesh = children[0]
-    expect(mainMesh.type).toBe('mesh')
-
-    const mainMeshProps = mainMesh.props as any
-    const meshChildren = React.Children.toArray(mainMeshProps.children) as React.ReactElement[]
-
-    // Check geometry
-    const geometry = meshChildren.find((child) => child.type === 'capsuleGeometry')
-    expect(geometry).toBeDefined()
-
-    const geometryProps = geometry?.props as any
-    // Check args: radius 0.5, length 1.8
-    expect(geometryProps?.args?.[0]).toBe(0.5)
-    expect(geometryProps?.args?.[1]).toBe(1.8)
-
-    // Check material
-    const material = meshChildren.find((child) => child.type === 'meshStandardMaterial')
-    expect(material).toBeDefined()
-
-    const materialProps = material?.props as any
-    expect(materialProps?.color).toBe('#ff00aa') // The placeholder color
+    // Should contain a primitive object (the rig)
+    const rigPrimitive = children.find(child => child.type === 'primitive')
+    expect(rigPrimitive).toBeDefined()
   })
 
   it('renders nothing when visible is false', () => {
     const invisibleActor = { ...mockActor, visible: false }
     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: invisibleActor }, null)
+    const result = CharacterRenderer.type.render({ actor: invisibleActor })
     expect(result).toBeNull()
   })
 
-  it('renders face direction indicator', () => {
-     // @ts-ignore
-    const result = CharacterRenderer.type.render({ actor: mockActor }, null) as React.ReactElement
+  it('renders selection indicator when selected', () => {
+    // @ts-ignore
+    const result = CharacterRenderer.type.render({ actor: mockActor, isSelected: true }) as React.ReactElement
     const props = result.props as any
     const children = React.Children.toArray(props.children) as React.ReactElement[]
 
-    // Second child should be the face mesh
-    const faceMesh = children[1]
-    expect(faceMesh.type).toBe('mesh')
-    const faceMeshProps = faceMesh.props as any
-    expect(faceMeshProps?.position?.[2]).toBe(0.4)
+    // Should have the rig primitive and the selection mesh
+    expect(children.length).toBe(2)
+    const selectionMesh = children.find(child => child.type === 'mesh')
+    expect(selectionMesh).toBeDefined()
+
+    const meshProps = selectionMesh?.props as any
+    const meshChildren = React.Children.toArray(meshProps.children) as React.ReactElement[]
+    expect(meshChildren.some(child => child.type === 'ringGeometry')).toBe(true)
   })
 })

--- a/packages/engine/src/scene/renderers/CharacterRenderer.tsx
+++ b/packages/engine/src/scene/renderers/CharacterRenderer.tsx
@@ -2,7 +2,7 @@
  * CharacterRenderer — R3F component for rendering a character actor.
  * Creates a procedural humanoid (or loads GLB), applies animation, face morphs, and eye tracking.
  */
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, memo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { createProceduralHumanoid } from '../../character/CharacterLoader'
@@ -28,7 +28,7 @@ interface CharacterRendererProps {
   onClick?: () => void
 }
 
-export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
+export const CharacterRenderer: React.FC<CharacterRendererProps> = memo(({
   actor,
   isSelected = false,
   onClick,
@@ -100,6 +100,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
 
   // Frame update — animation, face morphs, eye blinks
   useFrame((_state, delta) => {
+    if (!actor.visible) return
+
     // Skeletal animation
     if (animatorRef.current) {
       animatorRef.current.update(delta)
@@ -120,6 +122,8 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       faceMorphRef.current.setImmediate(eyeValues)
     }
   })
+
+  if (!actor.visible) return null
 
   return (
     <group
@@ -151,4 +155,6 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
       )}
     </group>
   )
-}
+})
+
+CharacterRenderer.displayName = 'CharacterRenderer'

--- a/packages/engine/src/scene/renderers/LightRenderer.tsx
+++ b/packages/engine/src/scene/renderers/LightRenderer.tsx
@@ -37,8 +37,8 @@ export const LightRenderer: React.FC<LightRendererProps> = memo(({
   const HelperClass = getHelperClass(lightType);
   // Pad args to constant length to satisfy React Hook rules (useHelper dependencies)
   const helperArgs = lightType === 'spot'
-    ? ['yellow', undefined]
-    : [lightType === 'directional' ? 1 : 0.5, 'yellow'];
+    ? ['#22C55E', undefined]
+    : [lightType === 'directional' ? 1 : 0.5, '#22C55E'];
 
   // useHelper expects a MutableRefObject or Object3D.
   // We cast the hook to unknown to avoid strict type checks on the helper constructor arguments

--- a/packages/engine/src/scene/renderers/PrimitiveRenderer.tsx
+++ b/packages/engine/src/scene/renderers/PrimitiveRenderer.tsx
@@ -75,7 +75,7 @@ export const PrimitiveRenderer: React.FC<PrimitiveRendererProps> = memo(({
         transparent={opacity < 1}
         wireframe={wireframe}
       />
-      {isSelected && <Edges color="yellow" threshold={15} />}
+      {isSelected && <Edges color="#22C55E" threshold={15} />}
     </mesh>
   )
 })


### PR DESCRIPTION
This PR addresses several issues in the engine renderers:
1. Standardizes selection and helper colors to '#22C55E' per 'Retro Futurism 71' design tokens.
2. Optimizes CharacterRenderer by wrapping it in `React.memo` and adding a visibility check that skips both rendering and frame updates when the actor is hidden.
3. Corrects a Rule of Hooks violation by ensuring conditional returns happen after all hook declarations.
4. Updates CharacterRenderer tests to verify the actual rig primitive instead of placeholder geometry and fixes the mock implementation for React.memo.

---
*PR created automatically by Jules for task [1991426719696048120](https://jules.google.com/task/1991426719696048120) started by @Fredess74*