### PR TITLE
Bundle Size Audit - May 2026

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,28 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-10
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/engine** | 132.2K | +61.2K |  |
+| **@Animatica/editor** | 3.3M | +3.3M |  |
+| **@Animatica/platform** | 179B | -25B |  |
+| **@Animatica/contracts** | 49B | -8.0K |  |
+| **@Animatica/web** | 102K | 0K | First Load JS (from build log) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.5M** (excluding web), **3.6M** (including web)
 
-## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+## Breakdown
+### @Animatica/contracts
+- `solidity-files-cache.json`: 49B
+### @Animatica/editor
+- `index.cjs`: 1.2M
+- `index.js`: 2.1M
+### @Animatica/engine
+- `index.cjs`: 55.3K
+- `index.js`: 76.9K
+### @Animatica/platform
+- `index.cjs`: 124B
+- `index.js`: 55B
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
-
-## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
-
-## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "1660.37ms",
+  "Vector3 Interpolation (10k ops)": "3230.29ms",
+  "Color Interpolation (10k ops)": "2198.73ms",
+  "Schema Validation Speed (100 runs)": "225.83ms",
+  "Store Playback Updates (10k ops)": "607.69ms",
+  "Store Add Actor (1k ops)": "696.47ms",
+  "Store Update Actor (1k ops)": "2918.96ms",
+  "Store Remove Actor (1k ops)": "1733.49ms"
 }


### PR DESCRIPTION
Performed a full build and bundle size audit for all packages. Updated `docs/BUNDLE_REPORT.md` with the latest size breakdown and comparisons. Also updated `reports/baseline_metrics.json` with current performance benchmarks.

---
*PR created automatically by Jules for task [6976123818382187745](https://jules.google.com/task/6976123818382187745) started by @Fredess74*