### PR TITLE
chore: bundle size audit 2026-05-11

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-11
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
-| **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
+| **@Animatica/web** | 102K | 0K | First Load JS (shared) |
+| **@Animatica/engine** | 135.4K | +64.4K | dist/index.js (78.8K) + dist/index.cjs (56.6K) |
+| **@Animatica/editor** | 3,489.0K | +3,413.0K | dist/index.js (2,181K) + dist/index.cjs (1,308K) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports |
+| **@Animatica/contracts** | 8K | 0K | Hardhat cache size |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3,632.6K** (excluding web), **3,734.6K** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.5M)
+- `dist/index.js`: 2,181K
+- `dist/index.cjs`: 1,308K
+- *Significant regression detected. Investigation required.*
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-11.
+- **MAJOR REGRESSION**: `@Animatica/editor` has grown from 76K to 3.5M. This is likely due to the inclusion of large UI component libraries or asset imports.
+- `@Animatica/engine` has doubled in size as animation and rendering logic was added.
+- `@Animatica/web` remains stable.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Audit `node_modules` and Vite config. Ensure `three` and other large libraries are being properly externalized or tree-shaken.
+- **@Animatica/engine**: Check if any unnecessary assets are being bundled into the JS.
+- **@Animatica/web**: Continue monitoring as more pages are added.


### PR DESCRIPTION
This PR updates the bundle size report following a full project build. It captures the current state of all workspace packages and highlights a significant size regression in the editor package for further investigation.

---
*PR created automatically by Jules for task [18200182833588684231](https://jules.google.com/task/18200182833588684231) started by @Fredess74*