### PR TITLE
feat(engine): implement Humanoid base and BoneController

### DIFF
--- a/packages/engine/src/character/BoneController.test.ts
+++ b/packages/engine/src/character/BoneController.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { BoneController } from './BoneController'
+import { BodyPose } from '../types'
+
+describe('BoneController', () => {
+    let bones: Map<string, THREE.Bone>
+    let controller: BoneController
+
+    beforeEach(() => {
+        bones = new Map()
+        const boneNames = ['Head', 'Spine', 'LeftArm', 'RightArm', 'LeftUpperLeg', 'RightUpperLeg']
+        boneNames.forEach(name => {
+            const bone = new THREE.Bone()
+            bone.name = name
+            bones.set(name, bone)
+        })
+        controller = new BoneController(bones)
+    })
+
+    it('should apply rotation to the head bone', () => {
+        const pose: BodyPose = {
+            head: [0.1, 0.2, 0.3]
+        }
+        controller.applyPose(pose)
+        const headBone = bones.get('Head')!
+        expect(headBone.rotation.x).toBeCloseTo(0.1)
+        expect(headBone.rotation.y).toBeCloseTo(0.2)
+        expect(headBone.rotation.z).toBeCloseTo(0.3)
+    })
+
+    it('should apply rotation to all supported bones', () => {
+        const pose: BodyPose = {
+            head: [0.1, 0, 0],
+            spine: [0, 0.2, 0],
+            leftArm: [0, 0, 0.3],
+            rightArm: [0.4, 0.4, 0.4],
+            leftLeg: [0.5, 0.5, 0.5],
+            rightLeg: [0.6, 0.6, 0.6]
+        }
+        controller.applyPose(pose)
+
+        expect(bones.get('Head')!.rotation.x).toBeCloseTo(0.1)
+        expect(bones.get('Spine')!.rotation.y).toBeCloseTo(0.2)
+        expect(bones.get('LeftArm')!.rotation.z).toBeCloseTo(0.3)
+        expect(bones.get('RightArm')!.rotation.x).toBeCloseTo(0.4)
+        expect(bones.get('LeftUpperLeg')!.rotation.x).toBeCloseTo(0.5)
+        expect(bones.get('RightUpperLeg')!.rotation.x).toBeCloseTo(0.6)
+    })
+
+    it('should skip bones that are not in the map', () => {
+        const customBones = new Map<string, THREE.Bone>()
+        const headBone = new THREE.Bone()
+        headBone.name = 'Head'
+        customBones.set('Head', headBone)
+
+        const customController = new BoneController(customBones)
+        const pose: BodyPose = {
+            head: [0.1, 0.1, 0.1],
+            spine: [0.2, 0.2, 0.2] // Spine is missing from map
+        }
+
+        customController.applyPose(pose)
+        expect(headBone.rotation.x).toBeCloseTo(0.1)
+        // No crash should occur for missing Spine
+    })
+
+    it('should handle undefined pose or properties gracefully', () => {
+        expect(() => controller.applyPose(undefined as any)).not.toThrow()
+        expect(() => controller.applyPose({})).not.toThrow()
+    })
+})

--- a/packages/engine/src/character/BoneController.ts
+++ b/packages/engine/src/character/BoneController.ts
@@ -1,0 +1,46 @@
+/**
+ * BoneController — Maps abstract BodyPose properties to Three.js humanoid bones.
+ * Handles rotation application in radians.
+ *
+ * @module @animatica/engine/character
+ */
+import * as THREE from 'three'
+import type { BodyPose } from '../types'
+
+/**
+ * Controller for managing individual bone rotations on a character rig.
+ */
+export class BoneController {
+    private bones: Map<string, THREE.Bone>
+
+    constructor(bones: Map<string, THREE.Bone>) {
+        this.bones = bones
+    }
+
+    /**
+     * Apply a BodyPose to the character skeleton.
+     * Maps abstract pose fields to standard bone names.
+     */
+    applyPose(pose: BodyPose): void {
+        if (!pose) return
+
+        this.setBoneRotation('Head', pose.head)
+        this.setBoneRotation('Spine', pose.spine)
+        this.setBoneRotation('LeftArm', pose.leftArm)
+        this.setBoneRotation('RightArm', pose.rightArm)
+        this.setBoneRotation('LeftUpperLeg', pose.leftLeg)
+        this.setBoneRotation('RightUpperLeg', pose.rightLeg)
+    }
+
+    /**
+     * Internal helper to set rotation on a named bone if it exists.
+     */
+    private setBoneRotation(name: string, rotation?: [number, number, number]): void {
+        if (!rotation) return
+
+        const bone = this.bones.get(name)
+        if (bone) {
+            bone.rotation.set(rotation[0], rotation[1], rotation[2])
+        }
+    }
+}

--- a/packages/engine/src/character/Humanoid.test.tsx
+++ b/packages/engine/src/character/Humanoid.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Humanoid } from './Humanoid'
+import { CharacterActor } from '../types'
+import * as THREE from 'three'
+
+// Mock R3F and Drei
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn((cb) => cb()),
+}))
+
+vi.mock('@react-three/drei', () => ({
+  useGLTF: vi.fn(() => ({
+    scene: new THREE.Group(),
+    animations: [],
+  })),
+  useAnimations: vi.fn(() => ({
+    actions: {},
+  })),
+}))
+
+describe('Humanoid', () => {
+  const mockActor: CharacterActor = {
+    id: '1',
+    name: 'Test Actor',
+    type: 'character',
+    transform: {
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
+    },
+    visible: true,
+    animation: 'idle',
+    morphTargets: {},
+    bodyPose: {
+      head: [0.1, 0, 0],
+    },
+    clothing: {},
+  }
+
+  it('renders without crashing when URL is provided', () => {
+    const { container } = render(
+      <Humanoid url="test.glb" actor={mockActor} />
+    )
+    expect(container).toBeDefined()
+  })
+
+  it('renders without crashing when URL is missing (fallback)', () => {
+    const { container } = render(<Humanoid actor={mockActor} />)
+    expect(container).toBeDefined()
+  })
+})

--- a/packages/engine/src/character/Humanoid.tsx
+++ b/packages/engine/src/character/Humanoid.tsx
@@ -1,0 +1,75 @@
+/**
+ * Humanoid — Base component for rigged character models.
+ * Loads GLB assets via useGLTF and applies skeletal posing.
+ * Falls back to a procedural mesh if the model is unavailable.
+ *
+ * @module @animatica/engine/character
+ */
+import React, { useMemo, useEffect } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { useGLTF, useAnimations } from '@react-three/drei'
+import { extractRig, createProceduralHumanoid, type CharacterRig } from './CharacterLoader'
+import { BoneController } from './BoneController'
+import type { CharacterActor } from '../types'
+
+export interface HumanoidProps {
+  /** URL of the GLB model to load. If omitted, renders procedural fallback. */
+  url?: string
+  /** The character actor data for pose/transform updates. */
+  actor: CharacterActor
+}
+
+/**
+ * Internal base component that handles bone posing and animations
+ * for a resolved CharacterRig.
+ */
+const HumanoidBase: React.FC<{ rig: CharacterRig; actor: CharacterActor }> = ({ rig, actor }) => {
+  const boneController = useMemo(() => new BoneController(rig.bones), [rig.bones])
+  const { actions } = useAnimations(rig.animations, rig.root)
+
+  useEffect(() => {
+    const idleAction = actions['idle'] || Object.values(actions)[0]
+    if (idleAction) {
+      idleAction.reset().fadeIn(0.5).play()
+    }
+    return () => {
+      if (idleAction) idleAction.fadeOut(0.5)
+    }
+  }, [actions])
+
+  useFrame(() => {
+    if (actor.bodyPose) {
+      boneController.applyPose(actor.bodyPose)
+    }
+  })
+
+  return <primitive object={rig.root} />
+}
+
+/**
+ * Component for loading and rendering a GLB-based humanoid.
+ */
+const HumanoidGLB: React.FC<{ url: string; actor: CharacterActor }> = ({ url, actor }) => {
+  const gltf = useGLTF(url)
+  const rig = useMemo(() => extractRig(gltf.scene, gltf.animations), [gltf])
+  return <HumanoidBase rig={rig} actor={actor} />
+}
+
+/**
+ * Component for rendering a procedural fallback humanoid.
+ */
+const HumanoidProcedural: React.FC<{ actor: CharacterActor }> = ({ actor }) => {
+  const rig = useMemo(() => createProceduralHumanoid(), [])
+  return <HumanoidBase rig={rig} actor={actor} />
+}
+
+/**
+ * Humanoid component.
+ * Dispatches to GLB or Procedural rendering based on the presence of a URL.
+ */
+export const Humanoid: React.FC<HumanoidProps> = ({ url, actor }) => {
+  if (url) {
+    return <HumanoidGLB url={url} actor={actor} />
+  }
+  return <HumanoidProcedural actor={actor} />
+}

--- a/packages/engine/src/character/index.ts
+++ b/packages/engine/src/character/index.ts
@@ -17,3 +17,5 @@ export type { EyeState } from './EyeController'
 export { CHARACTER_PRESETS, getPreset, getPresetIds } from './CharacterPresets'
 export type { CharacterPreset } from './CharacterPresets'
 
+export { BoneController } from './BoneController'
+export { Humanoid } from './Humanoid'


### PR DESCRIPTION
Implement the Humanoid base component and BoneController for skeletal posing.

- Created `BoneController` to map abstract BodyPose rotations to Three.js bones.
- Created `Humanoid` component with support for GLB loading and procedural fallback.
- Added unit tests for both `BoneController` and `Humanoid`.
- Fixed Rules of Hooks violation in `Humanoid` by splitting it into sub-components.
- Updated `character` barrel export.

---
*PR created automatically by Jules for task [5830816417439712055](https://jules.google.com/task/5830816417439712055) started by @Fredess74*