### PR TITLE
report: nightly status 2026-05-12

### DIFF
--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "445.59ms",
+  "Vector3 Interpolation (10k ops)": "540.05ms",
+  "Color Interpolation (10k ops)": "487.52ms",
+  "Schema Validation Speed (100 runs)": "64.80ms",
+  "Store Playback Updates (10k ops)": "200.18ms",
+  "Store Add Actor (1k ops)": "130.75ms",
+  "Store Update Actor (1k ops)": "1222.39ms",
+  "Store Remove Actor (1k ops)": "1013.73ms"
 }

--- a/reports/daily/2026-05-12.md
+++ b/reports/daily/2026-05-12.md
@@ -1,0 +1,43 @@
+# Nightly Status Report — 2026-05-12
+
+## Project Overview
+**Project Health Score:** 6/10
+Development remains active with significant progress in the character animation system and codebase audits. However, recent refactors have introduced regressions in the rendering test suites that need immediate attention.
+
+## Test Summary
+- **Total Tests:** 198
+- **Passing:** 191
+- **Failing:** 7
+- **Regressions Identified:**
+  - `packages/engine`: `CharacterRenderer.test.tsx` (3 failures) due to `undefined` render property on memoized component.
+  - `packages/editor`: `Viewport.test.tsx` (4 failures) due to missing `ContactShadows` export in `@react-three/drei` mock.
+
+## Issue Tracking
+- **Open Issues (Backlog):** 34
+- **Active Tasks (Agent Queue):** 28
+- **Tasks Completed Today:** 4 (License Audit, Humanoid Base, Store Optimization, 2D Storyboard Mode)
+
+## Commits Today (2026-05-12)
+- `5cd88d1` | google-labs-jules[bot] | chore(legal): license audit
+- `481f634` | google-labs-jules[bot] | feat(engine): implement Humanoid base and BoneController
+- `fcccf82` | google-labs-jules[bot] | refactor(store): optimize state
+
+## Files Changed
+- **Total Files Affected:** ~175
+- **Primary Packages:** `packages/engine`, `packages/editor`, `docs/`
+
+## Key Accomplishments
+- **License Audit:** Completed a full audit of 687 dependencies; documented MIT, Apache-2.0, BSD, and ISC licenses in `docs/LICENSE_AUDIT.md`.
+- **Character System:** Merged `Humanoid` base and `BoneController`, enabling procedural limb rotation and character loading.
+- **Store Optimization:** Refactored Zustand state for improved throughput and reduced re-renders.
+- **2D Mode:** Added storyboard mode foundation and expanded animation coverage.
+
+## Blockers Found
+- **Mock Regressions:** Vitest mocks for R3F and Drei components are out of sync with recent component changes, causing CI/test failures.
+- **Bundle Bloat:** `@Animatica/editor` bundle size has grown to 3.5M; needs tree-shaking investigation.
+
+## Recommendations for Tomorrow
+1. **Fix Rendering Tests:** Repair `CharacterRenderer` and `Viewport` test suites by updating mocks and fixing component access in tests.
+2. **Phase 2 Poses:** Implement character presets (cowboy, robot, android) using the new `BoneController`.
+3. **Viewport Polish:** Finalize gizmos and camera switching in the Editor Viewport.
+4. **Bundle Audit:** Investigate the size regression in the editor package to ensure performance stability.


### PR DESCRIPTION
Generated the comprehensive nightly status report for May 12, 2026. The report includes project health metrics, test pass/fail counts (191/7), open issue summaries, today's commits, and identification of blockers related to test regressions in CharacterRenderer and Viewport components.

---
*PR created automatically by Jules for task [5646256827206961568](https://jules.google.com/task/5646256827206961568) started by @Fredess74*