### PR TITLE
Bundle size audit - May 13, 2026

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,35 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-13
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | 0K | First Load JS (stable) |
+| **@Animatica/engine** | 135.4K | +64.4K | Includes index.js (78.8K) and index.cjs (56.6K) |
+| **@Animatica/editor** | 3.5M | +3.4M | Includes index.js (2.2M) and index.cjs (1.3M) |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.6M** (excluding web), **3.7M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.5M)
+- `dist/index.js`: 2,181.24K
+- `dist/index.cjs`: 1,307.75K
+- **Note:** Significant regression detected. Likely due to inclusion of large UI libraries or 3D assets.
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-13.
+- Major regression in `@Animatica/editor` (76K -> 3.5M).
+- Growth in `@Animatica/engine` as core features are added.
+- `@Animatica/web` and `@Animatica/platform` remain stable.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Immediate audit required to identify the cause of the 3.4M bloat. Check for unoptimized dependencies or bundled assets.
+- **@Animatica/engine**: Continue monitoring as more R3F components are integrated.
+- **@Animatica/web**: Maintain current First Load JS performance.


### PR DESCRIPTION
Updated the bundle size report with the latest audit results for 2026-05-13. The audit identified a significant size regression in the @Animatica/editor package (increasing from 76K to 3.5M). @Animatica/engine also saw growth to 135.4K, while other packages remained stable.

---
*PR created automatically by Jules for task [5136420653872818363](https://jules.google.com/task/5136420653872818363) started by @Fredess74*