### PR TITLE
Bundle Size Audit - 2026-05-14

### DIFF
--- a/docs/BUNDLE_REPORT.md
+++ b/docs/BUNDLE_REPORT.md
@@ -1,34 +1,34 @@
-# Bundle Size Report - 2026-02-25
+# Bundle Size Report - 2026-05-14
 
 ## Package Sizes
 
 | Package | Size | Comparison | Notes |
 | :--- | :--- | :--- | :--- |
-| **@Animatica/web** | 102K | NEW | First Load JS (built successfully) |
-| **@Animatica/engine** | 71K | +23K | Includes index.js (41K) and index.cjs (30K) |
-| **@Animatica/editor** | 76K | +64K | Includes index.js (46K) and index.cjs (30K) |
-| **@Animatica/platform** | 0.2K | -11.8K | Minimal exports only |
+| **@Animatica/web** | 102K | 0K | First Load JS (Next.js 15) |
+| **@Animatica/engine** | 135.4K | +64.4K | Growing with R3F components and animation logic |
+| **@Animatica/editor** | 3.5M | +3.4M | **REGRESSION**: Massive growth due to UI components and Three.js helpers |
+| **@Animatica/platform** | 0.2K | 0K | Minimal exports only |
 | **@Animatica/contracts** | 8K | 0K | Cache size (no compiled contracts) |
 
 ## Total Size
-**155.2K** (excluding web), **257.2K** (including web)
+**3.6M** (excluding web), **3.7M** (including web)
 
 ## Largest Dependencies
-### @Animatica/editor (76K)
-- `dist/index.js`: 46K
-- `dist/index.cjs`: 30K
+### @Animatica/editor (3.5M)
+- `dist/index.js`: 2.1M
+- `dist/index.cjs`: 1.3M
 
-### @Animatica/engine (71K)
-- `dist/index.js`: 41K
-- `dist/index.cjs`: 30K
+### @Animatica/engine (135.4K)
+- `dist/index.js`: 78.8K
+- `dist/index.cjs`: 56.6K
 
 ## Changes
-- Updated audit for 2026-02-25.
-- `apps/web` now builds successfully using Next.js 15.
-- Significant growth in `@Animatica/engine` and `@Animatica/editor` as features are implemented.
-- `@Animatica/platform` remains minimal.
+- Updated audit for 2026-05-14.
+- `@Animatica/editor` has seen a significant increase in size (3.5M), likely due to the inclusion of complex UI libraries or large 3D helpers.
+- `@Animatica/engine` size has nearly doubled as core rendering features are implemented.
+- `apps/web` remains stable at 102K First Load JS.
 
 ## Suggestions
-- **@Animatica/engine**: Monitor size as more R3F components are added.
-- **@Animatica/editor**: Keep an eye on UI component library weight.
-- **@Animatica/web**: 102K First Load JS is good for a Next.js app, but watch for bloating as more routes are added.
+- **@Animatica/editor**: Investigate tree-shaking and component-level code splitting to reduce the 3.5M bundle.
+- **@Animatica/engine**: Continue to monitor size as characters and advanced animation systems are added.
+- **Performance**: High bundle size for the editor may impact initial load times for contributors.

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "1622.30ms",
+  "Vector3 Interpolation (10k ops)": "2186.73ms",
+  "Color Interpolation (10k ops)": "1152.84ms",
+  "Schema Validation Speed (100 runs)": "140.62ms",
+  "Store Playback Updates (10k ops)": "606.57ms",
+  "Store Add Actor (1k ops)": "318.65ms",
+  "Store Update Actor (1k ops)": "2720.16ms",
+  "Store Remove Actor (1k ops)": "1170.29ms"
 }


### PR DESCRIPTION
Performed a comprehensive bundle size audit for the Animatica monorepo. Updated `docs/BUNDLE_REPORT.md` with the latest sizes for all packages and apps as of May 14, 2026. Identified a significant growth in the `@Animatica/editor` package (now 3.5M) and suggested investigation into tree-shaking and code splitting. The audit also involved updating `reports/baseline_metrics.json` with the latest performance data.

---
*PR created automatically by Jules for task [6032265406650053685](https://jules.google.com/task/6032265406650053685) started by @Fredess74*