### PR TITLE
Add Animation Engine Performance Benchmarks

### DIFF
--- a/packages/engine/src/__tests__/benchmark.test.ts
+++ b/packages/engine/src/__tests__/benchmark.test.ts
@@ -46,7 +46,8 @@ describe('Engine Benchmarks', () => {
 
             measure('Number Interpolation (10k ops)', () => {
                 for (let i = 0; i < 10000; i++) {
-                    const t = Math.random() * 10000;
+                    // Use deterministic values
+                    const t = (i * 1.5) % 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
@@ -64,7 +65,7 @@ describe('Engine Benchmarks', () => {
 
             measure('Vector3 Interpolation (10k ops)', () => {
                 for (let i = 0; i < 10000; i++) {
-                    const t = Math.random() * 10000;
+                    const t = (i * 1.5) % 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
@@ -82,7 +83,7 @@ describe('Engine Benchmarks', () => {
 
             measure('Color Interpolation (10k ops)', () => {
                 for (let i = 0; i < 10000; i++) {
-                    const t = Math.random() * 10000;
+                    const t = (i * 1.5) % 10000;
                     interpolateKeyframes(keyframes, t);
                 }
             });
@@ -98,7 +99,7 @@ describe('Engine Benchmarks', () => {
                     name: `Actor ${i}`,
                     type: 'primitive',
                     transform: {
-                        position: [Math.random() * 10, 0, 0],
+                        position: [i * 0.1, 0, 0],
                         rotation: [0, 0, 0],
                         scale: [1, 1, 1],
                     },

--- a/reports/baseline_metrics.json
+++ b/reports/baseline_metrics.json
@@ -1,10 +1,10 @@
 {
-  "Number Interpolation (10k ops)": "451.23ms",
-  "Vector3 Interpolation (10k ops)": "499.22ms",
-  "Color Interpolation (10k ops)": "542.74ms",
-  "Schema Validation Speed (100 runs)": "99.02ms",
-  "Store Playback Updates (10k ops)": "339.19ms",
-  "Store Add Actor (1k ops)": "188.94ms",
-  "Store Update Actor (1k ops)": "1456.54ms",
-  "Store Remove Actor (1k ops)": "1162.69ms"
+  "Number Interpolation (10k ops)": "465.60ms",
+  "Vector3 Interpolation (10k ops)": "534.81ms",
+  "Color Interpolation (10k ops)": "504.24ms",
+  "Schema Validation Speed (100 runs)": "147.83ms",
+  "Store Playback Updates (10k ops)": "246.35ms",
+  "Store Add Actor (1k ops)": "237.71ms",
+  "Store Update Actor (1k ops)": "1353.34ms",
+  "Store Remove Actor (1k ops)": "1094.49ms"
 }


### PR DESCRIPTION
I have implemented a comprehensive benchmarking suite for the animation engine in `packages/engine/src/__tests__/benchmark.test.ts`. This suite measures the performance of keyframe interpolation (Numbers, Vector3, and Colors), Zod schema validation for full project states, and Zustand store throughput (adding, updating, and removing actors). 

The benchmarks use deterministic data patterns to ensure stability across runs. Results are automatically recorded to `reports/baseline_metrics.json` via a Vitest `afterAll` hook, allowing for tracking performance over time. 

I also ensured that all existing tests pass and restored any unrelated files modified during the exploration process.

---
*PR created automatically by Jules for task [14381101790774687845](https://jules.google.com/task/14381101790774687845) started by @Fredess74*